### PR TITLE
Disable custom buttons when in observer mode

### DIFF
--- a/descriptor.mod
+++ b/descriptor.mod
@@ -1,0 +1,4 @@
+version="1.0"
+name="Community Mod Framework"
+supported_version="1.8.*"
+picture="thumbnail.png"

--- a/gui/com_gui_sidebar.gui
+++ b/gui/com_gui_sidebar.gui
@@ -82,7 +82,7 @@ vbox = {
 						size = { 47 47 }
 						position = { 0 1 }
 
-						enabled = "[ScriptedGui.IsValid(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
+						enabled = "[And(Not(IsObserver), ScriptedGui.IsValid(GuiScope.SetRoot(GetPlayer.MakeScope).End))]"
 
 						onclick = "[ScriptedGui.Execute(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
 						tooltip = "[Scope.GetIdeology.GetDesc]"


### PR DESCRIPTION
This fixes the problem that custom buttons are enabled but not clickable in observer mode.

What it does not fix is a spam of error messages:
```
[21:54:44][jomini_script_system.cpp:270]: Script system error!
  Error: untyped trigger [ Scoped object of type 'country' is not valid (Country  (4294967295)) ]
  Script location: file: common/scripted_guis/gate_technology_sgui.txt line: 6
```

These only appear when you are in observer mode and have not choosen a country.