### PR TITLE
Improved sidebar style

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ Then we need a scripted gui in the `common/scripted_guis/` folder corresponding 
 
 We then link those two via the localization of the ideology.
 Localizations can be found in `localization/<language>/`.
-Ideologies have two localization keys: \<ideology\> and \<ideology\>_desc
+Button ideologies have three localization keys: \<ideology\>, \<ideology\>_desc and \<ideology\>_tooltip
 
 The key \<ideology\> should contain the name of your scripted_gui.
-And the key \<ideology\>_desc contains the tooltip shown when hovering over the button (See [com_gui_l_english.yml](localization/english/com_gui_l_english.yml)).
+And the key \<ideology\>_desc contains the name shown when hovering over the button.
+The \<ideology\>_tooltip is optional and will be shown as a tooltip if you hover over the button (See [com_gui_l_english.yml](localization/english/com_gui_l_english.yml)).
 **Good practice here is to name the ideology and the scripted gui the same so even if you do not set the localization key for a language, the correct scripted gui is triggered!**
 
 And at last we need to add the button to the sidebar.

--- a/gui/com_gui_sidebar.gui
+++ b/gui/com_gui_sidebar.gui
@@ -166,6 +166,12 @@ vbox = {
                         }
                     }
 
+                    sidebar_tooltip_area = {
+                        # Only show tooltip when there is one defined
+                        visible = "[Not(ObjectsEqual(Localize(Concatenate(Scope.GetIdeology.GetNameNoFormatting, '_tooltip')), Concatenate(Scope.GetIdeology.GetNameNoFormatting, '_tooltip')))]"
+                        tooltip = "[Localize(Concatenate(Scope.GetIdeology.GetNameNoFormatting, '_tooltip'))]"
+                    }
+
 				}
 			}
 		}

--- a/gui/com_gui_sidebar.gui
+++ b/gui/com_gui_sidebar.gui
@@ -1,180 +1,873 @@
-# By Chris Kaiser | Bahmut
+#positions for sidepanel buttons
+#(they cant be in flowcontainer because of the way the label buttons is set up to scale with the longest localized text)
 
-# Heavily modified from original implementation
-# by LordR & Alexedishi
+@politics_position = 0
+@budget_position = 50
+@buildings_position = 100
+@trade_position = 150
+@military_position = 200
+@power_bloc_position = 250
 
-vbox = {
-	name = "com_gui_sidebar"
-	parentanchor = bottom|left
-	max_update_rate = 8
-	
-	layoutpolicy_vertical = expanding
-	margin_bottom = 50
-	spacing = 0
-	max_width = 50
-    margin_left = -25
-	
-	# Are there registered custom buttons?
-	# And is the pause menu shown?
-	# Are we in observer mode?
-	visible = "[And6( 
-		GetMetaPlayer.GetPlayedOrObservedCountry.IsValid, 
-		Not(IsObserver), 
-		Not(IsDataModelEmpty(GetGlobalList('custom_button_list'))),
-		IsInGame, 
-		Not(IsPauseMenuShown),
-		Not(IsGameOverScreenShown)
-	)]"
+@spacing_widget_1_position = 300
+@spacing_widget_size = 20
 
-    # Close custom panels when a base game panel is opened
-    # Same behavior as base game
-    state = {
-        trigger_when = "[InformationPanelBar.IsAnyPanelOpen]"
-        on_finish = "[GetVariableSystem.Clear('com_open_window')]"
+@diplomatic_position = 320
+@technology_position = 360
+@society_position = 400
+@population_position = 440
+@journal_position = 480
+@companies_position = 520
+
+@maplist_position = 580
+
+@spacing_widget_2_position = 560
+
+types com_sidebar_overwrite {
+
+    # This whole type as well as the constants
+    # above are directly copied from the base
+    # game.
+    # The only modification to this type is
+    # the inclusion of the custom_sidebar
+    type information_panel_bar = widget {
+        name = "information_panel_bar"
+        max_update_rate = 8
+        using = hud_visibility
+        allow_outside = yes
+        focuspolicy = all
+
+        position = { 0 200 }
+
+        state = {
+            name = _show
+            using = default_show_properties
+        }
+        state = {
+            name = _hide
+            using = default_hide_properties
+            on_start = "[InformationPanelBar.ClosePanel]"
+        }
+
+        ### BACKGROUND FOR LABEL BUTTONS
+        widget = {
+            size = { 100% 100% }
+            using = clickthrough_blocker
+            alpha = 0
+
+            background = {
+                using = dark_area
+                alpha = 1
+                margin_right = 40
+                margin_top = -5
+                margin_left = -25
+                margin_bottom = -5
+
+                modify_texture = {
+                    texture = "gfx/interface/masks/fade_horizontal_right.dds"
+                    spriteType = Corneredstretched
+                    spriteborder = { 0 0 }
+                    blend_mode = alphamultiply
+                }
+            }
+
+            state = {
+                name = show_sidebar_labels
+                alpha = 0.7
+                duration = 0.15
+                using = Animation_Curve_Default
+                start_sound = {
+                    soundeffect = "event:/SFX/UI/SideBar/list_show"
+                }
+            }
+            state = {
+                name = hide_sidebar_labels
+                alpha = 0
+                duration = 0.15
+                using = Animation_Curve_Default
+                start_sound = {
+                    soundeffect = "event:/SFX/UI/SideBar/list_hide"
+                }
+            }
+        }
+
+        container = {
+            position = { 0 -16 }
+
+            ### SIDEBAR BACKGROUND
+            flowcontainer = {
+                direction = vertical
+
+                icon = {
+                    texture = "gfx/interface/main_hud/sidebar_skin_bg_1.dds"
+                    size = { 50 171 }
+
+                    using = hud_shiny_effect
+                }
+
+                icon = {
+                    texture = "gfx/interface/main_hud/sidebar_skin_bg_2.dds"
+                    size = { 50 50 }
+
+                    using = hud_shiny_effect
+                }
+
+                icon = {
+                    texture = "gfx/interface/main_hud/sidebar_skin_bg_2.dds"
+                    size = { 50 50 }
+
+                    using = hud_shiny_effect
+                }
+
+                icon = {
+                    texture = "gfx/interface/main_hud/sidebar_skin_bg_3.dds"
+                    size = { 50 230 }
+
+                    using = hud_shiny_effect
+                }
+
+                icon = {
+                    texture = "gfx/interface/main_hud/sidebar_skin_bg_4.dds"
+                    size = { 50 40 }
+
+                    using = hud_shiny_effect
+                }
+
+                icon = {
+                    texture = "gfx/interface/main_hud/sidebar_skin_bg_5.dds"
+                    size = { 50 128 }
+
+                    using = hud_shiny_effect
+                }
+            }
+        }
+
+
+        ### LABEL BUTTONS
+        flowcontainer = {
+            name = "tutorial_highlight_sidebar"
+            direction = vertical
+            resizeparent = yes
+            margin = { 0 5 }
+            margin_right = -8 #margin to trim the hover area for the labels
+            onmousehierarchyenter = "[PdxGuiInterruptThenTriggerAllAnimations('hide_sidebar_labels','show_sidebar_labels')]"
+            onmousehierarchyleave = "[PdxGuiInterruptThenTriggerAllAnimations('show_sidebar_labels','hide_sidebar_labels')]"
+
+            container = {
+                name = "ingame_sidebar_buttons_container" # Don't rename otherwise `UiValidityCheck`s will just pretend to work
+
+                ### COMMUNITY SIDEBAR
+                custom_sidebar = {}
+
+                ### POWER BLOC
+
+                #two different buttons for two different onclicks
+                sidebar_label_button = {
+                    name = "power_bloc_member"
+                    visible = "[GetPlayer.IsInPowerBloc]"
+
+                    position = { -100 @power_bloc_position }
+                    blockoverride "onclick" {
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('power_bloc_panel', 'default|members|modifiers')]"
+                        input_action = "open_power_bloc"
+                    }
+                }
+
+                sidebar_label_button = {
+                    name = "power_bloc_not_member"
+                    visible = "[Not(GetPlayer.IsInPowerBloc)]"
+
+                    position = { -100 @power_bloc_position }
+                    blockoverride "onclick" {
+                        onclick = "[InformationPanelBar.OpenPanel('power_bloc_panel')]"
+                        input_action = "open_power_bloc"
+                    }
+                }
+
+
+                sidebar_label_text = {
+                    position = { -100 @power_bloc_position }
+                    text = "POWER_BLOC"
+                }
+
+                #two different buttons for two different onclicks
+
+                power_bloc_icon_button_widget = {
+                    visible = "[GetPlayer.IsInPowerBloc]"
+
+                    blockoverride "bloc_onclick" {
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('power_bloc_panel', 'default|members|modifiers')]"
+                    }
+                }
+
+                power_bloc_icon_button_widget = {
+                    visible = "[Not(GetPlayer.IsInPowerBloc)]"
+                    name = "tutorial_highlight_power_bloc_button_non_member"
+                    blockoverride "bloc_onclick" {
+                        onclick = "[InformationPanelBar.OpenPanel('power_bloc_panel')]"
+                    }
+                }
+
+                sidebar_tooltip_area = {
+                    position = { 0 @power_bloc_position }
+                    tooltip = "BUTTON_POWER_BLOC"
+                    input_action = "open_power_bloc"
+                }
+
+
+
+
+                ### POLITICS
+                sidebar_label_button = {
+                    position = { -100 @politics_position }
+                    blockoverride "onclick" {
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('politics', 'default|interest_groups|laws|institutions')]"
+                        onclick = "[GetVariableSystem.Clear('politics_overview_exile_pool')]"
+                        input_action = "open_politics"
+                    }
+                }
+                sidebar_label_text = {
+                    position = { -100 @politics_position }
+                    text = "POLITICS"
+                }
+                widget = {
+                    position = { 0 @politics_position }
+                    name = "tutorial_highlight_politics"
+                    using = clickthrough_blocker
+                    using = sidebar_button_size
+                    using = selected_sidepanel_animation
+                    blockoverride "selected_visibility" {
+                        visible = "[InformationPanelBar.IsPanelOpen('politics')]"
+                    }
+                    sidepanel_button_big = {
+                        blockoverride "icon" {
+                            texture = "gfx/interface/main_hud/pol_btn.dds"
+                        }
+                        blockoverride "button_selected" {
+                            visible = "[InformationPanelBar.IsPanelOpen('politics')]"
+                        }
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('politics', 'default|interest_groups|laws|institutions')]"
+                        onclick = "[GetVariableSystem.Clear('politics_overview_exile_pool')]"
+
+                        ### DEFAULT LAW ENACTMENT PROGRESS
+                        animated_progresspie = {
+                            visible = "[GetPlayer.HasProgressingLawEnactment]"
+                            parentanchor = center
+                            texture = "gfx/interface/main_hud/sidebar_progress.dds"
+                            size = { 100% 100% }
+                            framesize = { 100 100 }
+                            frame = 2
+                            datacontext = "[GetPlayer.GetLawBeingEnacted]"
+                            value = "[FixedPointToFloat(GetPlayer.GetLawEnactmentProgress)]"
+                            alwaystransparent = yes
+                        }
+
+                        ### IF LAW ENACTMENT CAN'T PROGRESS, E.G. BECAUSE OF AN ILLEGITMATE GOVERNMENT - RED PROGRESS
+                        animated_progresspie = {
+                            visible = "[Not(GetPlayer.HasProgressingLawEnactment)]"
+                            parentanchor = center
+                            texture = "gfx/interface/main_hud/sidebar_progress_red.dds"
+                            size = { 100% 100% }
+                            framesize = { 100 100 }
+                            frame = 2
+                            datacontext = "[GetPlayer.GetLawBeingEnacted]"
+                            value = "[FixedPointToFloat(GetPlayer.GetLawEnactmentProgress)]"
+                            alwaystransparent = yes
+                        }
+                    }
+                }
+                sidebar_tooltip_area = {
+                    position = { 0 @politics_position }
+                    tooltip = "BUTTON_POLITICS"
+                    input_action = "open_politics"
+                }
+
+                ### BUDGET
+                sidebar_label_button = {
+                    position = { -100 @budget_position }
+                    blockoverride "onclick" {
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('budget', 'default|states|assets')]"
+                        input_action = "open_budget"
+                    }
+                }
+                sidebar_label_text = {
+                    position = { -100 @budget_position }
+                    text = "BUDGET"
+                }
+                widget = {
+                    position = { 0 @budget_position }
+                    name = "tutorial_highlight_budget"
+                    using = clickthrough_blocker
+                    using = sidebar_button_size
+                    using = selected_sidepanel_animation
+                    blockoverride "selected_visibility" {
+                        visible = "[InformationPanelBar.IsPanelOpen('budget')]"
+                    }
+                    sidepanel_button_big = {
+                        blockoverride "icon" {
+                            texture = "gfx/interface/main_hud/budget_btn.dds"
+                        }
+                        blockoverride "button_selected" {
+                            visible = "[InformationPanelBar.IsPanelOpen('budget')]"
+                        }
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('budget', 'default|states|assets')]"
+                    }
+                }
+                sidebar_tooltip_area = {
+                    position = { 0 @budget_position }
+                    tooltip = "BUTTON_BUDGET"
+                    input_action = "open_budget"
+                }
+
+                ### BUILDINGS
+                sidebar_label_button = {
+                    position = { -100 @buildings_position }
+                    blockoverride "onclick" {
+                        onclick = "[InformationPanelBar.OpenCompactBuildingBrowserPanelCycleFilters( GetPlayer.Self, '|is_urban|is_rural|is_development' )]"
+                        input_action = "open_buildings"
+                    }
+                }
+                sidebar_label_text = {
+                    position = { -100 @buildings_position }
+                    text = "BUILDINGS"
+                }
+                widget = {
+                    position = { 0 @buildings_position }
+                    name = "tutorial_highlight_buildings"
+                    using = clickthrough_blocker
+                    using = sidebar_button_size
+                    using = selected_sidepanel_animation
+                    blockoverride "selected_visibility" {
+                        visible = "[InformationPanelBar.IsPanelOpen('compact_building_browser')]"
+                    }
+                    sidepanel_button_big = {
+                        blockoverride "icon" {
+                            texture = "gfx/interface/main_hud/production_overview_btn.dds"
+                        }
+                        blockoverride "button_selected" {
+                            visible = "[InformationPanelBar.IsPanelOpen('compact_building_browser')]"
+                        }
+                        onclick = "[InformationPanelBar.OpenCompactBuildingBrowserPanelCycleFilters( GetPlayer.Self, '|is_urban|is_rural|is_development' )]"
+                    }
+                }
+                sidebar_tooltip_area = {
+                    position = { 0 @buildings_position }
+                    tooltip = "BUTTON_BUILDINGS"
+                    input_action = "open_buildings"
+                }
+
+                ### TRADE OVERVIEW
+                sidebar_label_button = {
+                    position = { -100 @trade_position }
+                    blockoverride "onclick" {
+                        onclick = "[InformationPanelBar.OpenMarketPanelCycleTabs(AccessPlayer.AccessFirstMarket, 'market', 'default|trade_routes|food_security|states')]"
+                        input_action = "open_market"
+                    }
+                }
+                sidebar_label_text = {
+                    position = { -100 @trade_position }
+                    text = "MARKET"
+                }
+                widget = {
+                    position = { 0 @trade_position }
+                    name = "tutorial_highlight_market"
+                    using = clickthrough_blocker
+                    using = sidebar_button_size
+                    using = selected_sidepanel_animation
+                    blockoverride "selected_visibility" {
+                        visible = "[InformationPanelBar.IsPanelOpen('market')]"
+                    }
+                    sidepanel_button_big = {
+                        blockoverride "icon" {
+                            texture = "gfx/interface/main_hud/trade_overview_btn.dds"
+                        }
+                        blockoverride "button_selected" {
+                            visible = "[InformationPanelBar.IsPanelOpen('market')]"
+                        }
+                        onclick = "[InformationPanelBar.OpenMarketPanelCycleTabs(AccessPlayer.AccessFirstMarket, 'market', 'default|trade_routes|food_security|states')]"
+                    }
+                }
+                sidebar_tooltip_area = {
+                    position = { 0 @trade_position }
+                    tooltip = "BUTTON_TRADE_OVERVIEW"
+                    input_action = "open_market"
+                }
+
+                ### MILITARY
+                sidebar_label_button = {
+                    position = { -100 @military_position }
+                    blockoverride "onclick" {
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('military', 'army|mobilization|navy')]"
+                        input_action = "open_military"
+                    }
+                }
+                sidebar_label_text = {
+                    position = { -100 @military_position }
+                    text = "MILITARY"
+                }
+                widget = {
+                    position = { 0 @military_position }
+                    name = "tutorial_highlight_military"
+                    using = clickthrough_blocker
+                    using = sidebar_button_size
+                    using = selected_sidepanel_animation
+                    blockoverride "selected_visibility" {
+                        visible = "[InformationPanelBar.IsPanelOpen('military')]"
+                    }
+                    sidepanel_button_big = {
+                        blockoverride "icon" {
+                            texture = "gfx/interface/main_hud/mil_btn.dds"
+                        }
+                        blockoverride "button_selected" {
+                            visible = "[InformationPanelBar.IsPanelOpen('military')]"
+                        }
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('military', 'army|mobilization|navy')]"
+                    }
+                }
+                sidebar_tooltip_area = {
+                    position = { 0 @military_position }
+                    tooltip = "BUTTON_MILITARY"
+                    input_action = "open_military"
+                }
+
+                ### SECONDARY BUTTONS
+
+                #widget needed to prevent you from clicking on the map
+                widget = {
+                    using = clickthrough_blocker
+                    position = { 0 @spacing_widget_1_position }
+                    size = { 100% @spacing_widget_size }
+                }
+
+                ### DIPLOMATIC
+                sidebar_label_button_small = {
+                    enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
+                    position = { -100 @diplomatic_position }
+                    blockoverride "onclick" {
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('diplomatic_overview', 'default|subjects|release_subject|country_browser')]"
+                        input_action = "open_diplomatic"
+                    }
+                }
+                sidebar_label_text_small = {
+                    position = { -100 @diplomatic_position }
+                    text = "DIPLOMACY"
+                }
+                widget = {
+                    enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
+                    position = { 0 @diplomatic_position }
+                    name = "tutorial_highlight_diplomacy"
+                    using = clickthrough_blocker
+                    using = sidebar_button_size_small
+                    using = selected_sidepanel_animation_small
+                    blockoverride "selected_visibility" {
+                        visible = "[InformationPanelBar.IsPanelOpen('diplomatic_overview')]"
+                    }
+                    sidepanel_button_small = {
+                        blockoverride "icon" {
+                            texture = "gfx/interface/main_hud/dip_btn.dds"
+                        }
+                        blockoverride "button_selected" {
+                            visible = "[InformationPanelBar.IsPanelOpen('diplomatic_overview')]"
+                        }
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('diplomatic_overview', 'default|subjects|release_subject|country_browser')]"
+                    }
+                }
+                sidebar_tooltip_area_small = {
+                    position = { 0 @diplomatic_position }
+                    tooltip = "BUTTON_DIPLOMATIC_OVERVIEW"
+                    input_action = "open_diplomatic"
+                }
+
+                ### TECHNOLOGY
+                sidebar_label_button_small = {
+                    enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
+                    position = { -100 @technology_position }
+                    blockoverride "onclick" {
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('tech_tree', 'production|military|society')]"
+                        input_action = "open_technology"
+                    }
+                }
+                sidebar_label_text_small = {
+                    position = { -100 @technology_position }
+                    text = "TECHNOLOGY"
+                }
+                widget = {
+                    enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
+                    datacontext = "[AccessPlayer.AccessCurrentlyResearchedTechnology]"
+                    position = { 0 @technology_position }
+                    using = clickthrough_blocker
+                    using = sidebar_button_size_small
+                    using = selected_sidepanel_animation_small
+                    blockoverride "selected_visibility" {
+                        visible = "[InformationPanelBar.IsPanelOpen('tech_tree')]"
+                    }
+                    sidepanel_button_small = {
+                        blockoverride "icon" {
+                            texture = "gfx/interface/main_hud/tech_btn.dds"
+                        }
+                        blockoverride "button_selected" {
+                            visible = "[InformationPanelBar.IsPanelOpen('tech_tree')]"
+                        }
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('tech_tree', 'production|military|society')]"
+
+                        animated_progresspie = {
+                            visible = "[Technology.IsValid]"
+                            parentanchor = center
+                            texture = "gfx/interface/main_hud/sidebar_progress.dds"
+                            size = { 100% 100% }
+                            framesize = { 100 100 }
+                            frame = 2
+                            value = "[Technology.GetProgressPercentage(GetPlayer.Self)]"
+                            alwaystransparent = yes
+                        }
+                    }
+
+                    textbox = {
+                        parentanchor = right|top
+                        position = { -2 2 }
+                        autoresize = yes
+                        text = "TECH_QUEUE_BUTTON_NUMBER"
+                        visible = "[GreaterThan_int32( GetDataModelSize(AccessPlayer.GetResearchQueueTop), '(int32)0')]"
+                        align = left|nobaseline
+                        using = fontsize_small
+                        background = {
+                            using = default_background
+                            margin = { 8 5 }
+                        }
+                    }
+                }
+                sidebar_tooltip_area_small = {
+                    datacontext = "[AccessPlayer.AccessCurrentlyResearchedTechnology]"
+                    position = { 0 @technology_position }
+                    tooltip = "BUTTON_TECHNOLOGY"
+                    input_action = "open_technology"
+                }
+
+                ### COMPANIES
+                sidebar_label_button_small = {
+                    enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
+                    position = { -100 @companies_position }
+                    blockoverride "onclick" {
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('companies', 'default|potential_companies')]"
+                        input_action = "open_companies"
+                    }
+                }
+                sidebar_label_text_small = {
+                    position = { -100 @companies_position }
+                    text = "COMPANIES_OVERVIEW"
+                }
+                widget = {
+                    name = "tutorial_highlight_companies"
+                    enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
+                    position = { 0 @companies_position }
+                    using = clickthrough_blocker
+                    using = sidebar_button_size_small
+                    using = selected_sidepanel_animation_small
+                    blockoverride "selected_visibility" {
+                        visible = "[InformationPanelBar.IsPanelOpen('companies')]"
+                    }
+                    sidepanel_button_small = {
+                        blockoverride "icon" {
+                            texture = "gfx/interface/main_hud/companies_btn.dds"
+                        }
+                        blockoverride "button_selected" {
+                            visible = "[InformationPanelBar.IsPanelOpen('companies')]"
+                        }
+                        onclick = "[InformationPanelBar.OpenPanel('companies')]"
+                    }
+                }
+                sidebar_tooltip_area_small = {
+                    position = { 0 @companies_position }
+                    tooltip = "BUTTON_COMPANIES_OVERVIEW"
+                    input_action = "open_companies"
+                }
+
+                ### SOCIETY
+                sidebar_label_button_small = {
+                    enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
+                    position = { -100 @society_position }
+                    blockoverride "onclick" {
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('society', 'default|cultures|religions')]"
+                        input_action = "open_society"
+                    }
+                }
+                sidebar_label_text_small = {
+                    position = { -100 @society_position }
+                    text = "SOCIETY_OVERVIEW"
+                }
+                widget = {
+                    name = "tutorial_highlight_society"
+                    enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
+                    position = { 0 @society_position }
+                    using = clickthrough_blocker
+                    using = sidebar_button_size_small
+                    using = selected_sidepanel_animation_small
+                    blockoverride "selected_visibility" {
+                        visible = "[InformationPanelBar.IsPanelOpen('society')]"
+                    }
+                    sidepanel_button_small = {
+                        blockoverride "icon" {
+                            texture = "gfx/interface/main_hud/society_btn.dds"
+                        }
+                        blockoverride "button_selected" {
+                            visible = "[InformationPanelBar.IsPanelOpen('society')]"
+                        }
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('society', 'default|cultures|religions')]"
+                    }
+                }
+                sidebar_tooltip_area_small = {
+                    position = { 0 @society_position }
+                    tooltip = "BUTTON_SOCIETY_OVERVIEW"
+                    input_action = "open_society"
+                }
+
+                ### POPULATION
+                sidebar_label_button_small = {
+                    enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
+                    position = { -100 @population_position }
+                    blockoverride "onclick" {
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('pops_overview', 'default|population_charts|pop_list')]"
+                        input_action = "open_population"
+                    }
+                }
+                sidebar_label_text_small = {
+                    position = { -100 @population_position }
+                    text = "POPULATION"
+                }
+                widget = {
+                    name = "tutorial_highlight_pops"
+                    enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
+                    position = { 0 @population_position }
+                    using = clickthrough_blocker
+                    using = sidebar_button_size_small
+                    using = selected_sidepanel_animation_small
+                    blockoverride "selected_visibility" {
+                        visible = "[InformationPanelBar.IsPanelOpen('pops_overview')]"
+                    }
+                    sidepanel_button_small = {
+                        blockoverride "icon" {
+                            texture = "gfx/interface/main_hud/pops_btn.dds"
+                        }
+                        blockoverride "button_selected" {
+                            visible = "[InformationPanelBar.IsPanelOpen('pops_overview')]"
+                        }
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('pops_overview', 'default|population_charts|pop_list')]"
+                    }
+                }
+                sidebar_tooltip_area_small = {
+                    position = { 0 @population_position }
+                    tooltip = "BUTTON_POPULATION"
+                    input_action = "open_population"
+                }
+
+                ### JOURNAL
+                sidebar_label_button_small = {
+                    enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
+                    position = { -100 @journal_position }
+                    blockoverride "onclick" {
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('journal', 'default|inactive_journal_entries')]"
+                        input_action = "open_journal"
+                    }
+                }
+                sidebar_label_text_small = {
+                    position = { -100 @journal_position }
+                    text = "JOURNAL"
+                }
+                widget = {
+                    enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
+                    name = "tutorial_highlight_journal"
+                    position = { 0 @journal_position }
+                    using = clickthrough_blocker
+                    using = sidebar_button_size_small
+                    using = selected_sidepanel_animation_small
+                    blockoverride "selected_visibility" {
+                        visible = "[InformationPanelBar.IsPanelOpen('journal')]"
+                    }
+                    sidepanel_button_small = {
+                        blockoverride "icon" {
+                            texture = "gfx/interface/main_hud/journal_btn.dds"
+                        }
+                        blockoverride "button_selected" {
+                            visible = "[InformationPanelBar.IsPanelOpen('journal')]"
+                        }
+                        onclick = "[InformationPanelBar.OpenPanelCycleTabs('journal', 'default|inactive_journal_entries')]"
+                    }
+                    textbox = {
+                        parentanchor = right|top
+                        position = { -2 2 }
+                        autoresize = yes
+                        raw_text = "#bold [GetDataModelSize(AccessPlayer.AccessActiveJournalEntries)]#!"
+                        visible = "[GreaterThan_int32( GetDataModelSize(AccessPlayer.AccessActiveJournalEntries), '(int32)0')]"
+                        align = left|nobaseline
+                        using = fontsize_small
+                        background = {
+                            using = default_background
+                            margin = { 8 5 }
+                        }
+                    }
+                }
+                sidebar_tooltip_area_small = {
+                    position = { 0 @journal_position }
+                    tooltip = "BUTTON_JOURNAL"
+                    input_action = "open_journal"
+                }
+
+                #widget needed to prevent you from clicking on the map
+                widget = {
+                    using = clickthrough_blocker
+                    position = { 0 @spacing_widget_2_position }
+                    size = { 100% @spacing_widget_size }
+                }
+
+                ### MAP LIST
+                sidebar_label_button_small = {
+
+                    position = { -100 @maplist_position }
+                    blockoverride "onclick" {
+                        onclick = "[MapListPanelManager.ToggleCurrentPanel]"
+                        input_action = map_list
+                    }
+                }
+
+                sidebar_label_text_small = {
+                    position = { -100 @maplist_position }
+                    text = "MAP_LIST"
+                }
+
+                widget = {
+                    position = { 0 @maplist_position }
+                    using = clickthrough_blocker
+                    using = sidebar_button_size_small
+                    using = selected_sidepanel_animation_small
+                    blockoverride "selected_visibility" {
+                        visible = "[MapListPanelManager.IsVisible]"
+                    }
+                    sidepanel_button_small = {
+                        blockoverride "icon" {
+                            texture = "gfx/interface/main_hud/maplist_btn.dds"
+                        }
+                        blockoverride "button_selected" {
+                            visible = "[MapListPanelManager.IsVisible]"
+                        }
+                        onclick = "[MapListPanelManager.ToggleCurrentPanel]"
+                    }
+                }
+
+                sidebar_tooltip_area_small = {
+                    position = { 0 @maplist_position }
+                    tooltip = "MAP_LIST_TOOLTIP"
+                    input_action = map_list
+                }
+
+
+
+            }
+        }
     }
 
-	expand = {}
+    # This is the custom sidebar
+    # It is referenced above in the changes
+    # base game type
+    type custom_sidebar = flowcontainer {
+        position = { 0 @maplist_position }
+        parentanchor = top|left
+        direction = vertical
+        spacing = 0
 
-	widget = {
-		size = { 50 50 }
-		icon = {
-			using = hud_shiny_effect
-			size = { 50 50 }
-			framesize = { 100 100 }
-			frame = 0
+        # Don't show in observer mode
+        # or when there are no buttons
+        visible = "[And3(
+            GetMetaPlayer.GetPlayedOrObservedCountry.IsValid,
+            Not(IsObserver),
+            Not(IsDataModelEmpty(GetGlobalList('custom_button_list')))
+        )]"
 
-			position = { -75 77 }
+        #widget needed to prevent you from clicking on the map
+        widget = {
+            using = clickthrough_blocker
+            position = { 0 0 }
+            size = { 100% 60 }
+            icon = {
+                texture = "gfx/interface/main_hud/sidebar_skin_bg_5.dds"
+                size = { 100 120 }
+                spriteType = Corneredtiled
+                framesize = { 100 120 }
+                frame = 1
+                scale = 0.5
+            }
+        }
 
-			texture = "gfx/interface/main_hud/sidebar_skin_bg_1.dds"
-		}
-	}
+        flowcontainer = {
+            direction = vertical
+            datamodel = "[GetGlobalList('custom_button_list')]" # Get registered custom buttons
+            position = { 0 -100 }
 
-	vbox = {
-		# Add lower sidebar end
-		# Produces error: Widget cannot have a position in a layout
-		# Error comes from: parentanchor = bottom
-		# But the parentanchor works and is needed so it is at the end of the button list
-		widget = {
-			size = { 50 50 }
-			parentanchor = bottom
-
-			icon = {
-				using = hud_shiny_effect
-				size = { 50 50 }
-				framesize = { 100 100 }
-				frame = 0
-
-				position = { -75 23 }
-
-				mirror = vertical
-
-				texture = "gfx/interface/main_hud/sidebar_skin_bg_1.dds"
-
-			}
-		}
-
-		# For each registered button
-		vbox = {
-			datamodel = "[GetGlobalList('custom_button_list')]" # Get registered custom buttons
-            onmousehierarchyenter = "[PdxGuiInterruptThenTriggerAllAnimations('hide_custom_sidebar_labels','show_custom_sidebar_labels')]"
-            onmousehierarchyleave = "[PdxGuiInterruptThenTriggerAllAnimations('show_custom_sidebar_labels','hide_custom_sidebar_labels')]"
-
-			item = {
-				container = {
-					datacontext = "[GetScriptedGui(Scope.GetIdeology.GetNameNoFormatting)]"
+            item = {
+                container = {
+                    datacontext = "[GetScriptedGui(Scope.GetIdeology.GetNameNoFormatting)]"
                     enabled = "[ScriptedGui.IsValid(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
 
-                    icon = {
-                        texture = "gfx/interface/main_hud/sidebar_skin_bg_2.dds"
-                        parentanchor = center
-                        size = { 50 50 }
-                        position = { -75 0 }
-                        using = hud_shiny_effect
+                    widget = {
+                        parentanchor = bottom|left
+                        icon = {
+                            parentanchor = bottom|left
+                            position = { 0 20 }
+                            texture = "gfx/interface/main_hud/sidebar_skin_bg_1.dds"
+                            framesize = { 100 100 }
+                            size = { 100 100 }
+                            scale = 0.42
+                            frame = 1
+                            mirror = vertical
+                        }
                     }
 
-                    margin_widget = {
-                        margin_left = 40
-                        enabled = "[ScriptedGui.IsValid(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
-                        alpha = 0
-                        size = { 250 50 }
-
-                        using = sidepanel_label_background
-
-                        button = {
+                    sidebar_label_button_small = {
+                        position = { -100 0 }
+                        blockoverride "onclick" {
+                            enabled = "[ScriptedGui.IsValid(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
                             onclick = "[GetVariableSystem.Set('com_open_window', Scope.GetIdeology.GetNameNoFormatting)]"
                             onclick = "[ScriptedGui.Execute(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
-                            size = { 100% 100% }
-                            using = glow_button
-                            parentanchor = vcenter
-                        }
-
-                        state = {
-                            name = show_custom_sidebar_labels
-                            alpha = 1
-                            duration = 0.15
-                            using = Animation_Curve_Default
-                        }
-                        state = {
-                            name = hide_custom_sidebar_labels
-                            alpha = 0
-                            duration = 0.15
-                            using = Animation_Curve_Default
-                        }
-
-                        textbox = {
-                            margin_left = 50
-                            size = { -1 50 }
-
-                            align = left
-                            default_format "#bold"
-                            raw_text = "[Scope.GetIdeology.GetDesc]"
                         }
                     }
 
-                    button_icon_round = {
-                        name = "[Scope.GetIdeology.GetNameNoFormatting]"
+                    sidebar_label_text_small = {
+                        position = { -100 0 }
+                        raw_text = "[Scope.GetIdeology.GetDesc]"
+                    }
 
-                        parentanchor = center
-                        size = { 47 47 }
-                        position = { -75 0 }
-
-                        enabled = "[ScriptedGui.IsValid(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
-
-                        onclick = "[GetVariableSystem.Set('com_open_window', Scope.GetIdeology.GetNameNoFormatting)]"
-                        onclick = "[ScriptedGui.Execute(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
-
-
-                        blockoverride "icon" {
-                            texture = "[Scope.GetIdeology.GetTexture]"
+                    widget = {
+                        size = { 50 40 }
+                        using = clickthrough_blocker
+                        using = sidebar_button_size_small
+                        using = selected_sidepanel_animation_small
+                        blockoverride "selected_visibility" {
+                            visible = "[GetVariableSystem.HasValue('com_open_window', Scope.GetIdeology.GetNameNoFormatting)]"
                         }
-
-                        blockoverride "icon_size" {
-                            size = { 35 35 }
+                        background = {
+                            texture = "gfx/interface/main_hud/sidebar_skin_bg_4.dds"
                         }
-
-                        state = {
-                            name = _mouse_enter
-                            alpha = 1
-                            duration = 0.7
-                            using = Animation_Curve_Default
-                        }
-                        state = {
-                            name = _mouse_leave
-                            alpha = 0.7
-                            duration = 0.2
-                            using = Animation_Curve_Default
+                        sidepanel_button_small = {
+                            position = { -4 0 }
+                            blockoverride "icon" {
+                                scale = 0.7
+                                texture = "[Scope.GetIdeology.GetTexture]"
+                            }
+                            blockoverride "button_selected" {
+                                visible = "[GetVariableSystem.HasValue('com_open_window', Scope.GetIdeology.GetNameNoFormatting)]"
+                            }
+                            enabled = "[ScriptedGui.IsValid(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
+                            onclick = "[GetVariableSystem.Set('com_open_window', Scope.GetIdeology.GetNameNoFormatting)]"
+                            onclick = "[ScriptedGui.Execute(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
                         }
                     }
 
-                    sidebar_tooltip_area = {
+                    sidebar_tooltip_area_small = {
+                        position = { 0 0 }
                         # Only show tooltip when there is one defined
                         visible = "[Not(ObjectsEqual(Localize(Concatenate(Scope.GetIdeology.GetNameNoFormatting, '_tooltip')), Concatenate(Scope.GetIdeology.GetNameNoFormatting, '_tooltip')))]"
                         tooltip = "[Localize(Concatenate(Scope.GetIdeology.GetNameNoFormatting, '_tooltip'))]"
                     }
-
-				}
-			}
-		}
-	}
-	
+                }
+            }
+        }
+    }
 }

--- a/gui/com_gui_sidebar.gui
+++ b/gui/com_gui_sidebar.gui
@@ -12,6 +12,7 @@ vbox = {
 	margin_bottom = 50
 	spacing = 0
 	max_width = 50
+    margin_left = -25
 	
 	# Are there registered custom buttons?
 	# And is the pause menu shown?
@@ -25,6 +26,13 @@ vbox = {
 		Not(IsGameOverScreenShown)
 	)]"
 
+    # Close custom panels when a base game panel is opened
+    # Same behavior as base game
+    state = {
+        trigger_when = "[InformationPanelBar.IsAnyPanelOpen]"
+        on_finish = "[GetVariableSystem.Clear('com_open_window')]"
+    }
+
 	expand = {}
 
 	widget = {
@@ -35,7 +43,7 @@ vbox = {
 			framesize = { 100 100 }
 			frame = 0
 
-			position = { 0 77 }
+			position = { -75 77 }
 
 			texture = "gfx/interface/main_hud/sidebar_skin_bg_1.dds"
 		}
@@ -56,7 +64,7 @@ vbox = {
 				framesize = { 100 100 }
 				frame = 0
 
-				position = { 0 23 }
+				position = { -75 23 }
 
 				mirror = vertical
 
@@ -68,58 +76,96 @@ vbox = {
 		# For each registered button
 		vbox = {
 			datamodel = "[GetGlobalList('custom_button_list')]" # Get registered custom buttons
+            onmousehierarchyenter = "[PdxGuiInterruptThenTriggerAllAnimations('hide_custom_sidebar_labels','show_custom_sidebar_labels')]"
+            onmousehierarchyleave = "[PdxGuiInterruptThenTriggerAllAnimations('show_custom_sidebar_labels','hide_custom_sidebar_labels')]"
 
 			item = {
-				widget = {
+				container = {
 					datacontext = "[GetScriptedGui(Scope.GetIdeology.GetNameNoFormatting)]"
+                    enabled = "[ScriptedGui.IsValid(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
 
-					size = { 50 50 }
+                    icon = {
+                        texture = "gfx/interface/main_hud/sidebar_skin_bg_2.dds"
+                        parentanchor = center
+                        size = { 50 50 }
+                        position = { -75 0 }
+                        using = hud_shiny_effect
+                    }
 
-					icon = {
-						texture = "gfx/interface/main_hud/sidebar_skin_bg_2.dds"
+                    margin_widget = {
+                        margin_left = 40
+                        enabled = "[ScriptedGui.IsValid(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
+                        alpha = 0
+                        size = { 250 50 }
 
-						parentanchor = center
-						size = { 50 50 }
-						using = hud_shiny_effect
-					}
+                        using = sidepanel_label_background
 
-					button_icon_round = {
-						name = "[Scope.GetIdeology.GetNameNoFormatting]"
+                        button = {
+                            onclick = "[GetVariableSystem.Set('com_open_window', Scope.GetIdeology.GetNameNoFormatting)]"
+                            onclick = "[ScriptedGui.Execute(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
+                            size = { 100% 100% }
+                            using = glow_button
+                            parentanchor = vcenter
+                        }
 
-						parentanchor = center
-						size = { 47 47 }
-						position = { 0 1 }
+                        state = {
+                            name = show_custom_sidebar_labels
+                            alpha = 1
+                            duration = 0.15
+                            using = Animation_Curve_Default
+                        }
+                        state = {
+                            name = hide_custom_sidebar_labels
+                            alpha = 0
+                            duration = 0.15
+                            using = Animation_Curve_Default
+                        }
 
-						enabled = "[ScriptedGui.IsValid(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
+                        textbox = {
+                            margin_left = 50
+                            size = { -1 50 }
 
-						onclick = "[GetVariableSystem.Set('com_open_window', Scope.GetIdeology.GetNameNoFormatting)]"
-						onclick = "[ScriptedGui.Execute(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
+                            align = left
+                            default_format "#bold"
+                            raw_text = "[Scope.GetIdeology.GetDesc]"
+                        }
+                    }
 
-						tooltip = "[Scope.GetIdeology.GetDesc]"
+                    button_icon_round = {
+                        name = "[Scope.GetIdeology.GetNameNoFormatting]"
+
+                        parentanchor = center
+                        size = { 47 47 }
+                        position = { -75 0 }
+
+                        enabled = "[ScriptedGui.IsValid(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
+
+                        onclick = "[GetVariableSystem.Set('com_open_window', Scope.GetIdeology.GetNameNoFormatting)]"
+                        onclick = "[ScriptedGui.Execute(GuiScope.SetRoot(GetPlayer.MakeScope).End)]"
 
 
-						blockoverride "icon" {
-							texture = "[Scope.GetIdeology.GetTexture]"
-						}
+                        blockoverride "icon" {
+                            texture = "[Scope.GetIdeology.GetTexture]"
+                        }
 
-						blockoverride "icon_size" {
-							size = { 35 35 }
-						}
+                        blockoverride "icon_size" {
+                            size = { 35 35 }
+                        }
 
-						state = {
-							name = _mouse_enter
-							alpha = 1
-							duration = 0.7
-							using = Animation_Curve_Default
-						}
+                        state = {
+                            name = _mouse_enter
+                            alpha = 1
+                            duration = 0.7
+                            using = Animation_Curve_Default
+                        }
+                        state = {
+                            name = _mouse_leave
+                            alpha = 0.7
+                            duration = 0.2
+                            using = Animation_Curve_Default
+                        }
+                    }
 
-						state = {
-							name = _mouse_leave
-							alpha = 0.7
-							duration = 0.2
-							using = Animation_Curve_Default
-						}
-					}
 				}
 			}
 		}

--- a/gui/scripted_widgets/com_gui_scripted_widgets.txt
+++ b/gui/scripted_widgets/com_gui_scripted_widgets.txt
@@ -1,1 +1,0 @@
-﻿gui/com_gui_sidebar.gui = com_gui_sidebar

--- a/localization/braz_por/com_gui_l_braz_por.yml
+++ b/localization/braz_por/com_gui_l_braz_por.yml
@@ -1,6 +1,7 @@
 ﻿l_braz_por:
   # Scripted gui used by button
   gui_sidebar_example_button: "gui_sidebar_example_button"
-  # Description of button that is shown as a tooltip
-  gui_sidebar_example_button_desc: "Manage Example Stuff"
- 
+  # Name of the button that is shown in the hover popout
+  gui_sidebar_example_button_desc: "Example"
+  # Tooltip shown when hovering over the button
+  gui_sidebar_example_button_tooltip: "When clicking this button nothing happens"

--- a/localization/english/com_gui_l_english.yml
+++ b/localization/english/com_gui_l_english.yml
@@ -1,7 +1,8 @@
-﻿l_spanish:
+﻿l_english:
   # Scripted gui used by button
   gui_sidebar_example_button: "gui_sidebar_example_button"
   # Name of the button that is shown in the hover popout
   gui_sidebar_example_button_desc: "Example"
   # Tooltip shown when hovering over the button
   gui_sidebar_example_button_tooltip: "When clicking this button nothing happens"
+ 

--- a/localization/french/com_gui_l_french.yml
+++ b/localization/french/com_gui_l_french.yml
@@ -1,6 +1,7 @@
 ﻿l_french:
   # Scripted gui used by button
   gui_sidebar_example_button: "gui_sidebar_example_button"
-  # Description of button that is shown as a tooltip
-  gui_sidebar_example_button_desc: "Manage Example Stuff"
- 
+  # Name of the button that is shown in the hover popout
+  gui_sidebar_example_button_desc: "Example"
+  # Tooltip shown when hovering over the button
+  gui_sidebar_example_button_tooltip: "When clicking this button nothing happens"

--- a/localization/german/com_gui_l_german.yml
+++ b/localization/german/com_gui_l_german.yml
@@ -1,6 +1,7 @@
 ﻿l_german:
   # Scripted gui used by button
   gui_sidebar_example_button: "gui_sidebar_example_button"
-  # Description of button that is shown as a tooltip
-  gui_sidebar_example_button_desc: "Manage Example Stuff"
- 
+  # Name of the button that is shown in the hover popout
+  gui_sidebar_example_button_desc: "Example"
+  # Tooltip shown when hovering over the button
+  gui_sidebar_example_button_tooltip: "When clicking this button nothing happens"

--- a/localization/japanese/com_gui_l_japanese.yml
+++ b/localization/japanese/com_gui_l_japanese.yml
@@ -1,6 +1,7 @@
 ﻿l_japanese:
   # Scripted gui used by button
   gui_sidebar_example_button: "gui_sidebar_example_button"
-  # Description of button that is shown as a tooltip
-  gui_sidebar_example_button_desc: "Manage Example Stuff"
- 
+  # Name of the button that is shown in the hover popout
+  gui_sidebar_example_button_desc: "Example"
+  # Tooltip shown when hovering over the button
+  gui_sidebar_example_button_tooltip: "When clicking this button nothing happens"

--- a/localization/korean/com_gui_l_korean.yml
+++ b/localization/korean/com_gui_l_korean.yml
@@ -1,6 +1,7 @@
 ﻿l_korean:
   # Scripted gui used by button
   gui_sidebar_example_button: "gui_sidebar_example_button"
-  # Description of button that is shown as a tooltip
-  gui_sidebar_example_button_desc: "Manage Example Stuff"
- 
+  # Name of the button that is shown in the hover popout
+  gui_sidebar_example_button_desc: "Example"
+  # Tooltip shown when hovering over the button
+  gui_sidebar_example_button_tooltip: "When clicking this button nothing happens"

--- a/localization/polish/com_gui_l_polish.yml
+++ b/localization/polish/com_gui_l_polish.yml
@@ -1,6 +1,7 @@
 ﻿l_polish:
   # Scripted gui used by button
   gui_sidebar_example_button: "gui_sidebar_example_button"
-  # Description of button that is shown as a tooltip
-  gui_sidebar_example_button_desc: "Manage Example Stuff"
- 
+  # Name of the button that is shown in the hover popout
+  gui_sidebar_example_button_desc: "Example"
+  # Tooltip shown when hovering over the button
+  gui_sidebar_example_button_tooltip: "When clicking this button nothing happens"

--- a/localization/russian/com_gui_l_russian.yml
+++ b/localization/russian/com_gui_l_russian.yml
@@ -1,6 +1,7 @@
 ﻿l_russian:
   # Scripted gui used by button
   gui_sidebar_example_button: "gui_sidebar_example_button"
-  # Description of button that is shown as a tooltip
-  gui_sidebar_example_button_desc: "Manage Example Stuff"
- 
+  # Name of the button that is shown in the hover popout
+  gui_sidebar_example_button_desc: "Example"
+  # Tooltip shown when hovering over the button
+  gui_sidebar_example_button_tooltip: "When clicking this button nothing happens"

--- a/localization/simp_chinese/com_gui_l_simp_chinese.yml
+++ b/localization/simp_chinese/com_gui_l_simp_chinese.yml
@@ -1,6 +1,7 @@
 ﻿l_simp_chinese:
   # Scripted gui used by button
   gui_sidebar_example_button: "gui_sidebar_example_button"
-  # Description of button that is shown as a tooltip
-  gui_sidebar_example_button_desc: "Manage Example Stuff"
- 
+  # Name of the button that is shown in the hover popout
+  gui_sidebar_example_button_desc: "Example"
+  # Tooltip shown when hovering over the button
+  gui_sidebar_example_button_tooltip: "When clicking this button nothing happens"

--- a/localization/turkish/com_gui_l_turkish.yml
+++ b/localization/turkish/com_gui_l_turkish.yml
@@ -1,6 +1,7 @@
 ﻿l_turkish:
   # Scripted gui used by button
   gui_sidebar_example_button: "gui_sidebar_example_button"
-  # Description of button that is shown as a tooltip
-  gui_sidebar_example_button_desc: "Manage Example Stuff"
- 
+  # Name of the button that is shown in the hover popout
+  gui_sidebar_example_button_desc: "Example"
+  # Tooltip shown when hovering over the button
+  gui_sidebar_example_button_tooltip: "When clicking this button nothing happens"


### PR DESCRIPTION
Hi,

I have improved how the sidebar works.

Improvements:

- When you hover over the sidebar you now see the names of the buttons (previously the tooltip text)
- When a base game panel/window is opened it closes custom windows. Same behavior as between base game windows.

Screenshot:
![image](https://github.com/user-attachments/assets/12724169-6c3f-4a90-a504-7d8fa48d52b2)

Regards,

Chris