### PR TITLE
Add a weekly event framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ https://steamcommunity.com/sharedfiles/filedetails/?id=3385002128
 * [Keybinds](#keybinds)
 * [Additional Modifier Icons](#additional-modifier-icons)
 * [Heir Blocker](#heir-blocker)
+* [Weekly Event Framework](#weekly-event-framework)
 
 # Setting Dependency
 
@@ -386,3 +387,14 @@ To allow randomly-generated heirs again, simply remove the variable.
 Note:
 1. No considerations have been made regarding any failsafes. You are solely responsible for unblocking heirs later, even if the country switches away from a government type with hereditary transfer of power.
 2. Heirs created via `create_character` and heirs set via `set_heir` are *not* blocked, as they do not count as a "natural" heir birth. This means the variable does not need to be briefly unset when generating or setting heirs via script, such as for historical heirs.
+
+# Weekly Event Framework
+
+This is a framework to allow for a weekly firing script event on any day of the week, without a hidden journal entry being used.
+
+To use:
+1. In `com_weekly_on_action.txt`, rename `set_weekly_on_action_example` to a name of your choice and add this to the `on_monthly_pulse` on_actions block.
+2. In the same file, rename the `com_run_weekly_event_example` to a relevant name
+3. In `com_weekly_event.txt`, rename `com_run_weekly_event_example` to the same as what you named it above. Set weekday to your required day, rename the global variable `com_added_days` and replace `example_on_action_weekly` with your weekly on action.
+4. Go back to `com_weekly_on_action.txt` and add your weekly on action as a new on action.
+5. Rename `com_weekly_on_action.txt` and `com_weekly_event.txt` to something that won't conflict with other mods using this framework.

--- a/common/on_actions/com_weekly_on_action.txt
+++ b/common/on_actions/com_weekly_on_action.txt
@@ -1,0 +1,25 @@
+﻿# IMPORTANT: If you want to add a new event, add a new file with this on_monthly_pulse block,
+# using your own set_weekly_on_action with a unique name.
+# Otherwise, you will interfere with other mods using the same system.
+
+on_monthly_pulse = {
+    on_actions = {
+        #set_weekly_on_action_example
+    }
+}
+
+
+set_weekly_on_action_example = { # Example setter of weekly on actions
+    effect = {
+        com_run_weekly_event_example = yes
+    }
+}
+
+example_on_action_weekly = { # Example on action, replace with your own
+    effect = {
+        set_variable = {
+            name = example_on_action_weekly_run_date
+            value = game_date
+        }
+    }
+}

--- a/common/script_values/com_weekly_event_script_values.txt
+++ b/common/script_values/com_weekly_event_script_values.txt
@@ -1,0 +1,138 @@
+﻿com_calculate_added_days = {
+    value = 7
+    add = local_var:weekday
+    subtract = com_day_of_the_week
+    modulo = 7
+}
+
+# Returns current day of the week, with 0 being Sunday and 6 being Saturday.
+com_day_of_the_week = {
+    # Determining the day of the week:
+    value = year
+    subtract = 1836 # one day added per year, since v3 has no leap years
+    add = 3 # wednesday start date
+
+    # add offset for different months
+    if = {
+        limit = {
+            OR = {
+                month = 1
+                month = 2
+                month = 10
+            }
+        }
+        add = 3
+    }
+    else_if = {
+        limit = {
+            OR = {
+                month = 3
+                month = 6
+            }
+        }
+        add = 6
+    }
+    else_if = {
+        limit = {
+            month = 4
+        }
+        add = 1
+    }
+    else_if = {
+        limit = {
+            month = 5
+        }
+        add = 4
+    }
+    else_if = {
+        limit = {
+            month = 7
+        }
+        add = 2
+    }
+    else_if = {
+        limit = {
+            OR = {
+                month = 8
+                month = 11
+            }
+        }
+        add = 5
+    }
+    modulo = 7
+}
+
+com_month_length = {
+    if = {
+        limit = {
+            month = 0
+        }
+        value = 31
+    }
+    else_if = {
+        limit = {
+            month = 1
+        }
+        value = 28
+    }
+    else_if = {
+        limit = {
+            month = 2
+        }
+        value = 31
+    }
+    else_if = {
+        limit = {
+            month = 3
+        }
+        value = 30
+    }
+    else_if = {
+        limit = {
+            month = 4
+        }
+        value = 31
+    }
+    else_if = {
+        limit = {
+            month = 5
+        }
+        value = 30
+    }
+    else_if = {
+        limit = {
+            month = 6
+        }
+        value = 31
+    }
+    else_if = {
+        limit = {
+            month = 7
+        }
+        value = 31
+    }
+    else_if = {
+        limit = {
+            month = 8
+        }
+        value = 30
+    }
+    else_if = {
+        limit = {
+            month = 9
+        }
+        value = 31
+    }
+    else_if = {
+        limit = {
+            month = 10
+        }
+        value = 30
+    }
+    else_if = {
+        limit = {
+            month = 11
+        }
+        value = 31
+    }
+}

--- a/common/scripted_effects/com_delay_event_switch.txt
+++ b/common/scripted_effects/com_delay_event_switch.txt
@@ -1,0 +1,101 @@
+﻿com_delay_event_switch = {
+    switch = {
+        trigger = $num_days$
+        0 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 0 }
+        }
+        1 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 1 }
+        }
+        2 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 2 }
+        }
+        3 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 3 }
+        }
+        4 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 4 }
+        }
+        5 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 5 }
+        }
+        6 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 6 }
+        }
+        7 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 7 }
+        }
+        8 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 8 }
+        }
+        9 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 9 }
+        }
+        10 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 10 }
+        }
+        11 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 11 }
+        }
+        12 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 12 }
+        }
+        13 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 13 }
+        }
+        14 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 14 }
+        }
+        15 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 15 }
+        }
+        16 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 16 }
+        }
+        17 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 17 }
+        }
+        18 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 18 }
+        }
+        19 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 19 }
+        }
+        20 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 20 }
+        }
+        21 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 21 }
+        }
+        22 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 22 }
+        }
+        23 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 23 }
+        }
+        24 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 24 }
+        }
+        25 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 25 }
+        }
+        26 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 26 }
+        }
+        27 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 27 }
+        }
+        28 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 28 }
+        }
+        29 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 29 }
+        }
+        30 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 30 }
+        }
+        31 = {
+            my_trigger_event = {on_action_name = $on_action_name$ num_days = 31 }
+        }
+    }
+}

--- a/common/scripted_effects/com_trigger_event.txt
+++ b/common/scripted_effects/com_trigger_event.txt
@@ -1,0 +1,6 @@
+﻿my_trigger_event = {
+    trigger_event = {
+        on_action = $on_action_name$
+        days = $num_days$
+    }
+}

--- a/common/scripted_effects/com_weekly_event.txt
+++ b/common/scripted_effects/com_weekly_event.txt
@@ -1,0 +1,34 @@
+﻿com_run_weekly_event_example = {
+    set_local_variable = {
+        name = weekday
+        value = 1 # Set value for weekday you want the event to fire on, 0-6 is Sunday-Saturday.
+                  # Here, I have set the value to monday, which is 1
+    }
+    set_global_variable = {
+        name = com_added_days
+        value = com_calculate_added_days
+    }
+    every_country = { # This example event is running for every country - can be per state, or scopeless/global, etc.
+        set_local_variable = {
+            name = event_day
+            value = global_var:com_added_days
+        }
+        set_local_variable = {
+            name = month_length
+            value = com_month_length
+        }
+        while = {
+            limit = {
+                local_var:event_day < local_var:month_length
+            }
+            com_delay_event_switch = {
+                on_action_name = example_on_action_weekly # Replace with your on action that you want to run weekly
+                num_days = local_var:event_day
+            }
+            change_local_variable = {
+                name = event_day
+                add = 7
+            }
+        }
+    }
+}


### PR DESCRIPTION
I've added a framework for adding a weekly event. The user will have to create their own files based off [com_weekly_on_action.txt](https://github.com/dingbat32/Community-Mod-Framework/blob/3d62c238574531ae95dcc6363c84e3af44b88c7b/common/on_actions/com_weekly_on_action.txt) and [com_weekly_event.txt](https://github.com/dingbat32/Community-Mod-Framework/blob/3d62c238574531ae95dcc6363c84e3af44b88c7b/common/scripted_effects/com_weekly_event.txt). The day of the week that the on_action fires on can be changed by setting the local variable weekday to a different value in com_weekly_event.txt.