### PR TITLE
Usable and ergonomic JE Group hiding system

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,3 +398,15 @@ To use:
 3. In `com_weekly_event.txt`, rename `com_run_weekly_event_example` to the same as what you named it above. Set weekday to your required day, rename the global variable `com_added_days` and replace `example_on_action_weekly` with your weekly on action.
 4. Go back to `com_weekly_on_action.txt` and add your weekly on action as a new on action.
 5. Rename `com_weekly_on_action.txt` and `com_weekly_event.txt` to something that won't conflict with other mods using this framework.
+
+
+# Hide/Show Journal Entry Groups
+
+This allows for hiding and showing any Journal Entry Group.
+
+Usage:
+`com_hide_journal_entry_group = { name = je_group_historical_content }` 
+This would hide all National Agenda (`je_group_historical_content`) Journal Entries.
+
+`com_show_journal_entry_group = { name = je_group_historical_content }` 
+This would show them again.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ https://steamcommunity.com/sharedfiles/filedetails/?id=3385002128
 * [Additional Modifier Icons](#additional-modifier-icons)
 * [Heir Blocker](#heir-blocker)
 * [Weekly Event Framework](#weekly-event-framework)
+* [Hide/Show Journal Entry Groups](#hideshow-journal-entry-groups)
 
 # Setting Dependency
 

--- a/common/scripted_effects/com_hide_journal_group.txt
+++ b/common/scripted_effects/com_hide_journal_group.txt
@@ -1,0 +1,13 @@
+com_hide_journal_entry_group = {
+	add_to_global_variable_list = {
+		name = com_hidden_journal_groups
+		target = flag:$name$
+	}
+}
+
+com_show_journal_entry_group = {
+	remove_list_global_variable = {
+		name = com_hidden_journal_groups
+		target = flag:$name$
+	}
+}

--- a/common/scripted_guis/com_hidden_journals.txt
+++ b/common/scripted_guis/com_hidden_journals.txt
@@ -1,0 +1,12 @@
+com_journal_entry_group_hidden = {
+	scope = country
+    saved_scopes = {
+        group_name
+    }
+    is_shown = {
+        is_target_in_global_variable_list = {
+            name = com_hidden_journal_groups
+            target = scope:group_name
+        }
+    }
+}

--- a/gui/com_gui_journal.gui
+++ b/gui/com_gui_journal.gui
@@ -172,6 +172,7 @@ types journal_overwrites {
 
 						item = {
 							flowcontainer = {
+								visible = "[Not(GetScriptedGui('com_journal_entry_group_hidden').IsShown(GuiScope.SetRoot(AccessPlayer.MakeScope).AddScope('group_name', MakeScopeFlag(JournalEntryGroup.GetKey)).End))]"
 								direction = vertical
 								textbox = {
 									text = "[JournalEntryGroup.GetName]"
@@ -262,6 +263,7 @@ types journal_overwrites {
 					item = {
 						flowcontainer = {
 							direction = vertical
+							visible = "[Not(GetScriptedGui('com_journal_entry_group_hidden').IsShown(GuiScope.SetRoot(AccessPlayer.MakeScope).AddScope('group_name', MakeScopeFlag(JournalEntryGroup.GetKey)).End))]"
 							textbox = {
 								text = "[JournalEntryGroup.GetName]"
 								autoresize = yes


### PR DESCRIPTION
This is a simple JE Group hiding system, that allows for, for example, dynamic JE use as custom widgets.
It provides two effects as front facing API: `com_hide_journal_entry_group` and `com_show_journal_entry_group`.
These both take a parameter `name`. For example `com_hide_journal_entry_group = { name = je_group_historical_content }` hides all National Agenda JEs.