### PR TITLE
Improved Sandbox objective button visuals

### DIFF
--- a/gui/com_gui_objectives.gui
+++ b/gui/com_gui_objectives.gui
@@ -215,6 +215,30 @@ types objective_overwrites {
                                     size = { 100% 42 }
                                 }
                             }
+                            
+                            # CMF - Duplicate header for when an objective is selected
+                            # Compared to the vanilla header, it's dimmed
+                            default_header_clean = {
+                                visible = "[GameSetup.HasSelectedObjective]"
+                                blockoverride "text" {
+                                    text = "SANDBOX"
+                                }
+                                blockoverride "header_mask" {
+                                    using = frame_small_mask_top
+                                }
+                                blockoverride "size" {
+                                    size = { 100% 42 }
+                                }
+                                blockoverride "header_background" { # Darken header
+                                    background = {
+                                        using = default_header_bg
+                                        modify_texture = {
+                                            texture    = "gfx/interface/backgrounds/paper_bg_dark.dds"
+                                            blend_mode = overlay
+                                        }
+                                    }
+                                }
+                            }
 
                             widget = {
                                 size = { 100% 100 }
@@ -263,7 +287,7 @@ types objective_overwrites {
 
                             # CMF - Adjusted dark area behind text that looks better in the smaller space
                             widget = {
-                                size = { 100% 100 }
+                                size = { 100% 100% } # Y size must be 100% (i.e. not absolutely sized)
                                 parentanchor = hcenter|bottom
                                 visible = "[GameSetup.HasSelectedObjective]"
 
@@ -284,30 +308,6 @@ types objective_overwrites {
                                         autoresize = yes
                                         multiline = yes
                                         using = fontsize_medium
-                                    }
-                                }
-                            }
-
-                            # CMF - Duplicate header for when an objective is selected
-                            # Compared to the vanilla header, it's dimmed & will sit above the text area instead of below
-                            default_header_clean = {
-                                visible = "[GameSetup.HasSelectedObjective]"
-                                blockoverride "text" {
-                                    text = "SANDBOX"
-                                }
-                                blockoverride "header_mask" {
-                                    using = frame_small_mask_top
-                                }
-                                blockoverride "size" {
-                                    size = { 100% 42 }
-                                }
-                                blockoverride "header_background" { # Darken header
-                                    background = {
-                                        using = default_header_bg
-                                        modify_texture = {
-                                            texture    = "gfx/interface/backgrounds/paper_bg_dark.dds"
-                                            blend_mode = overlay
-                                        }
                                     }
                                 }
                             }

--- a/gui/com_gui_objectives.gui
+++ b/gui/com_gui_objectives.gui
@@ -204,7 +204,6 @@ types objective_overwrites {
                             }
 
                             default_header_clean = {
-                                visible = "[Not(GameSetup.HasSelectedObjective)]" # CMF
                                 blockoverride "text" {
                                     text = "SANDBOX"
                                 }
@@ -213,30 +212,6 @@ types objective_overwrites {
                                 }
                                 blockoverride "size" {
                                     size = { 100% 42 }
-                                }
-                            }
-                            
-                            # CMF - Duplicate header for when an objective is selected
-                            # Compared to the vanilla header, it's dimmed
-                            default_header_clean = {
-                                visible = "[GameSetup.HasSelectedObjective]"
-                                blockoverride "text" {
-                                    text = "SANDBOX"
-                                }
-                                blockoverride "header_mask" {
-                                    using = frame_small_mask_top
-                                }
-                                blockoverride "size" {
-                                    size = { 100% 42 }
-                                }
-                                blockoverride "header_background" { # Darken header
-                                    background = {
-                                        using = default_header_bg
-                                        modify_texture = {
-                                            texture    = "gfx/interface/backgrounds/paper_bg_dark.dds"
-                                            blend_mode = overlay
-                                        }
-                                    }
                                 }
                             }
 
@@ -249,7 +224,7 @@ types objective_overwrites {
                                     background = {
                                         using = dark_area
                                         alpha = 0.7
-                                        using = frame_small_mask
+                                        # using = frame_small_mask # CMF - has no major impact + looks cleaner removed
 
                                         modify_texture = {
                                             texture = "gfx/interface/masks/fade_horizontal_center.dds"
@@ -291,24 +266,22 @@ types objective_overwrites {
                                 parentanchor = hcenter|bottom
                                 visible = "[GameSetup.HasSelectedObjective]"
 
-                                vbox = {
-                                    background = {
-                                        using = dark_area
-                                        alpha = 0.75
-                                        using = frame_small_mask
-                                    }
+                                background = {
+                                    using = dark_area
+                                    alpha = 0.8
+                                    using = frame_small_mask
+                                }
 
-                                    textbox = {
-                                        text = "com_no_sandbox_warning"
-                                        align = hcenter|nobaseline
-                                        default_format = "#red;bold;italic;shadow"
-                                        margin_top = 20
-                                        minimumsize = { 260 -1 }
-                                        maximumsize = { 260 -1 }
-                                        autoresize = yes
-                                        multiline = yes
-                                        using = fontsize_medium
-                                    }
+                                textbox = {
+                                    parentanchor = center
+                                    text = "com_no_sandbox_warning"
+                                    align = hcenter|nobaseline
+                                    default_format = "#red;bold;italic;shadow"
+                                    minimumsize = { 260 -1 }
+                                    maximumsize = { 260 -1 }
+                                    autoresize = yes
+                                    multiline = yes
+                                    using = fontsize_medium
                                 }
                             }
 


### PR DESCRIPTION
* Better fix for the visual conflict on 16:9 monitors
  * Dark area behind the sandbox warning text is now relatively scaled instead of absolutely scaled
  * Preserves sandbox button bottom margin
* Centered warning text
* Deleted (now-unnecessary) duplicate header