### PR TITLE
Updated cooltips for 1.9

### DIFF
--- a/gui/cooltip.gui
+++ b/gui/cooltip.gui
@@ -7,12 +7,13 @@
 
 #### COMMUNITY GUI COOLTIPS ####
 
-## Western Clothes: Redux ##
-WCR_conservative_IG_list_tooltip = {
-    name = "WCR_conservative_IGs_tooltip"
-}
-WCR_progressive_IG_list_tooltip = {
-    name = "WCR_progressive_IGs_tooltip"
+## Sample
+COM_sample_cooltip = {
+    # Identifier of a cooltip entry must have a corresponding GUI type.
+    #
+    # `name` parameter is the identifier fed into a `#tooltip` formatting tag in localization.
+    # It does not need to match the name of the cooltip GUI type, or any GUI type at all. It just needs to be unique.
+    name = "COM_sample_cooltip_name"
 }
 
 #### VANILLA COOLTIPS BELOW HERE ####

--- a/gui/cooltip.gui
+++ b/gui/cooltip.gui
@@ -53,6 +53,30 @@ FancyTooltip_DecreeType = {
 	name = "DecreeTypeTooltip"
 }
 
+FancyTooltip_Treaty = {
+	name = "TreatyTooltip"
+}
+
+FancyTooltip_ArticleType = {
+	name = "ArticleTypeTooltip"
+}
+
+FancyTooltip_Article = {
+	name = "ArticleTooltip"
+}
+
+FancyTooltip_ArticleWithCountryContext = {
+	name = "ArticleWithCountryContextTooltip"
+}
+
+FancyTooltip_ArticleDraft = {
+	name = "ArticleDraftTooltip"
+}
+
+FancyTooltip_ArticleDraftWithCountryContext = {
+	name = "ArticleDraftWithCountryContextTooltip"
+}
+
 FancyTooltip_IG = {
 	name = "IGTooltip"
 }
@@ -105,8 +129,20 @@ FancyTooltip_Pop = {
 	name = "PopTooltip"
 }
 
+FancyTooltip_Company = {
+	name = "CompanyTooltip"
+}
+
 FancyTooltip_CompanyType = {
 	name = "CompanyTypeTooltip"
+}
+
+FancyTooltip_CompanyCharter = {
+	name = "CompanyCharterTooltip"
+}
+
+FancyTooltip_CompanyCharterType = {
+	name = "CompanyCharterTypeTooltip"
 }
 
 FancyTooltip_Country = {
@@ -229,8 +265,20 @@ FancyTooltip_PoliticalMovement = {
 	name = "PoliticalMovementTooltip"
 }
 
+FancyTooltip_PoliticalMovementType = {
+	name = "PoliticalMovementTypeTooltip"
+}
+
 FancyTooltip_StrategicRegion = {
 	name = "StrategicRegionTooltip"
+	state = {
+		name = _show
+		on_start = "[AccessHighlightManager.HighlightStrategicRegion(StrategicRegion.Self)]"
+	}
+	state = {
+		name = _hide
+		on_start = "[AccessHighlightManager.RemoveHighlight]"
+	}
 }
 
 FancyTooltip_CanalType = {
@@ -458,6 +506,10 @@ GraphTooltip_ConstructionGoodsExpense = {
 
 GraphTooltip_SubsidiesExpense = {
 	name = "SubsidiesExpenseTooltip"
+}
+
+GraphTooltip_SubventionsExpense = {
+	name = "SubventionsExpenseTooltip"
 }
 
 GraphTooltip_InterestExpense = {

--- a/gui/zz_community_cooltip_types.gui
+++ b/gui/zz_community_cooltip_types.gui
@@ -9,9 +9,9 @@ types TooltipTypes {
     
     #### UNSHARED ####
     
-    ## Western Clothes: Redux ##
-    type WCR_conservative_IG_list_tooltip = TooltipWidgetType {}
-    type WCR_progressive_IG_list_tooltip = TooltipWidgetType {}
+    ## Sample
+    ## Identifier of the type must match an entry in cooltip.gui
+    type COM_sample_cooltip = TooltipWidgetType {}
     
     #### ========================================================================================================== ####
     


### PR DESCRIPTION
- 1.9 vanilla cooltips have been added to `cooltips.gui`
- WCR no longer uses cooltips, and as such, its cooltip-related definitions have been deleted
- Added sample dummy cooltip definitions to replace the WCR ones to provide a basic example of how the cooltip files are meant to be organized