### PR TITLE
Updated to MPM v1.7.0

### DIFF
--- a/gui/00_MPM_building_browser_panel.gui
+++ b/gui/00_MPM_building_browser_panel.gui
@@ -18,11 +18,8 @@
 
 @all_filter_selected_alpha = 0.35
 
-# MPM Framework constants
-@MPM_max_PMs_per_line = 4
-
 types building_browser_panel_types {
-    type building_browser_building_item = flowcontainer {
+	type building_browser_building_item = flowcontainer {
 		tooltipwidget = {
 			FancyTooltip_Building = {}
 		}
@@ -92,7 +89,6 @@ types building_browser_panel_types {
 		### DOWNSIZE / EXPAND
 		widget = {
 			size = { 120 @spreadsheet_height }
-            parentanchor = vcenter # MPM
 
 			building_level_controls = {
 				parentanchor = center
@@ -109,33 +105,41 @@ types building_browser_panel_types {
 
 		vertical_divider = {}
 
-		flowcontainer = { # MPM - widget -> flowcontainer
-			# size = { 220 @spreadsheet_height }
-			# condensed_building_information_pms = {
+		widget = {
+			size = { 220 @spreadsheet_height }
+			# condensed_building_information_pms = { # MPM
 				# parentanchor = center
+
+				# blockoverride "trade_center_extra_info_position" {
+					# position = { 110 0 }
+				# }
+
+				# blockoverride "trade_center_extra_info_size" {
+					# size = { 60 23 }
+				# }
 			# }
             
-            minimumsize = { 220 @spreadsheet_height } # MPM
-            direction = vertical # MPM
-            container = {
+            MPM_pms_area_building = {
                 parentanchor = hcenter
-                condensed_building_information_pms = {
-                    blockoverride "trade_center_extra_info_position" {
-                        position = { 110 0 }
-                    }
-
-                    blockoverride "trade_center_extra_info_size" {
-                        size = { 60 23 }
-                    }
+                position = { 0 -5 }
+                
+                blockoverride scrollarea_size {
+                    size = { 200 55 }
                 }
-            }
-            flowcontainer = { # MPM
-                visible = "[GreaterThan_int32(GetDataModelSize(Building.AccessProductionMethodGroups), '(int32)4')]"
-                parentanchor = hcenter
-                MPM_condensed_building_information_pms_row_2 = {
-                    blockoverride "pm_wrap" {
-                        datamodel_wrap = @MPM_max_PMs_per_line
-                    }
+                blockoverride scrollbar_size {
+                    size = { 8 4 }
+                }
+                blockoverride track_size {
+                    size = { 8 2 }
+                }
+                blockoverride slider_size {
+                    framesize = { 40 4 }
+                }
+                blockoverride pm_size {
+                    size = { 50 50 }
+                }
+                blockoverride pm_icon_size {
+                    size = { 40 40 }
                 }
             }
 		}
@@ -145,7 +149,6 @@ types building_browser_panel_types {
 		# EMPLOYMENT
 		widget = {
 			size = { 130 @spreadsheet_height }
-            parentanchor = vcenter # MPM
 
 			widget = {
 				size = { 110 30 }
@@ -203,7 +206,6 @@ types building_browser_panel_types {
 		# CASH RESERVES
 		widget = {
 			size = { 130 @spreadsheet_height }
-            parentanchor = vcenter # MPM
 
 			widget = {
 				alpha = "[TransparentIfFalse(Building.IsActive)]"
@@ -297,7 +299,6 @@ types building_browser_panel_types {
 
 		widget = {
 			size = { 90 @spreadsheet_height }
-            parentanchor = vcenter # MPM
 
 			textbox = {
 				visible = "[And(Not(Building.IsGovernmentFunded), Not(Building.IsSubsistenceBuilding))]"
@@ -314,7 +315,6 @@ types building_browser_panel_types {
 
 		widget = {
 			size = { 180 @spreadsheet_height }
-            parentanchor = vcenter # MPM
 
 			### ACTION BUTTONS
 			flowcontainer = {
@@ -422,7 +422,6 @@ types building_browser_panel_types {
 
 					widget = {
 						size = { @spreadsheet_header_height @spreadsheet_header_height }
-                        parentanchor = vcenter # MPM
 
 						icon = {
 							parentanchor = center
@@ -434,7 +433,7 @@ types building_browser_panel_types {
 					section_header_button = {
 
 						blockoverride "layout" {
-							size = { 420 100% } # MPM # { 420 @spreadsheet_header_height }
+							size = { 420 @spreadsheet_header_height }
 						}
 
 						blockoverride "fontsize" {
@@ -462,7 +461,6 @@ types building_browser_panel_types {
 
 					widget = {
 						size = { 120 @spreadsheet_header_height }
-                        parentanchor = vcenter # MPM
 
 						textbox = {
 							text = "[BuildingBrowserBuildingTypeItem.GetTotalFilteredSizeDesc]"
@@ -499,85 +497,33 @@ types building_browser_panel_types {
 
 					vertical_divider = {}
 
-					flowcontainer = { # MPM Framework (changed to flowcontainer from widget)
-						minimumsize   = { 220 @spreadsheet_header_height } # MPM Framework
-						parentanchor  = vcenter
-                        direction     = vertical # MPM
-                        margin_top    = 15 # MPM
-                        margin_left   = 7 # MPM
-                        margin_bottom = 15 # MPM
+					widget = {
+						size = { 220 @spreadsheet_header_height }
+						parentanchor = vcenter
                         
-                        fixedgridbox = {
-							datamodel = "[BuildingBrowserBuildingTypeItem.GetBuildingType.AccessProductionMethodGroups]"
-							flipdirection = yes
-							addcolumn = 52
-							addrow = 50
-							# position = { 6 0 } # MPM
-							# parentanchor = vcenter # MPM
-                            datamodel_wrap = @MPM_max_PMs_per_line # MPM Framework - PM wraparound
-
-							item = {
-								widget = {
-									size = { 50 50 }
-									tooltip = "BUILDING_TYPE_BULK_CHANGE_TOOLTIP"
-									using = tooltip_above
-
-									button = {
-										visible = "[NotEqualTo_int32( GetDataModelSize( ProductionMethodGroup.AccessCountryProductionMethods( GetPlayer.Self ) ), '(int32)1' )]"
-										distribute_visual_state = no
-										inherit_visual_state = no
-										using = expand_button_bg_dropdown
-										size = { 100% 100% }
-										onclick = "[BuildingBrowserBuildingTypeItem.ToggleSwitchProductionMethodMenu( ProductionMethodGroup.AccessSelf, PdxGuiWidget.AccessSelf)]"
-										enabled = "[Not(IsDataModelEmpty(BuildingBrowserBuildingTypeItem.GetBuildingsInCountry))]"
-									}
-
-									### pm icon
-									icon = {
-										visible = "[BuildingBrowserBuildingTypeItem.HasAllSameProductionMethod( ProductionMethodGroup.Self )]"
-										size = { 40 40 }
-										parentanchor = center
-										texture = "[BuildingBrowserBuildingTypeItem.GetAllSameProductionMethodTexture( ProductionMethodGroup.Self )]"
-									}
-
-									### mixed pm icon
-									icon = {
-										visible = "[Not( BuildingBrowserBuildingTypeItem.HasAllSameProductionMethod( ProductionMethodGroup.Self ) )]"
-										size = { 35 35 }
-										parentanchor = center
-										texture = "[ProductionMethodGroup.GetMixedIcon]"
-									}
-
-									### new pm
-									has_new_pm_icon = {
-										position = { -2 2 }
-										parentanchor = bottom|left
-										blockoverride "visible" {
-											visible = "[And(GetPlayer.HasNewProductionMethodInGroup( ProductionMethodGroup.Self ), Not(IsDataModelEmpty(BuildingBrowserBuildingTypeItem.GetBuildingsInCountry)))]"
-										}
-									}
-
-
-									### nr available
-									textbox = {
-										raw_text = "#bold [ProductionMethodGroup.GetNumAvailableOptionsForBuildingType(BuildingBrowserBuildingTypeItem.GetBuildingType.AccessSelf)]#!"
-										parentanchor = top|right
-										position = { -5 0 }
-										autoresize = yes
-										align = right|nobaseline
-										visible = "[GreaterThan_int32( ProductionMethodGroup.GetNumAvailableOptionsForBuildingType(BuildingBrowserBuildingTypeItem.GetBuildingType.AccessSelf), '(int32)1')]"
-										tooltip = "PRODUCTION_METHOD_OPTIONS_BULK"
-										using = tooltip_above
-										using = fontsize_small
-
-										background = {
-											using = default_background
-											margin = { 8 4 }
-										}
-									}
-								}
-							}
-						}
+                        # MPM - The entire fixedgridbox has been replaced with this thing
+                        MPM_pms_area_building_type = {
+                            parentanchor = center
+                            
+                            blockoverride scrollarea_size {
+                                size = { 200 60 }
+                            }
+                            blockoverride scrollbar_size {
+                                size = { 8 8 }
+                            }
+                            blockoverride track_size {
+                                size = { 8 4 }
+                            }
+                            blockoverride slider_size {
+                                framesize = { 40 8 }
+                            }
+                            blockoverride pm_size {
+                                size = { 50 50 }
+                            }
+                            blockoverride pm_icon_size {
+                                size = { 40 40 }
+                            }
+                        }
 					}
 
 					vertical_divider = {}
@@ -598,7 +544,6 @@ types building_browser_panel_types {
 
 					widget = {
 						size = { 130 @spreadsheet_header_height }
-                        parentanchor = vcenter # MPM
 
 						textbox = {
 							raw_text = "[BuildingBrowserBuildingTypeItem.GetTotalFilteredCashReserves|D] / #maximum [BuildingBrowserBuildingTypeItem.GetTotalFilteredMaxCashReserves|D]#!"
@@ -618,7 +563,6 @@ types building_browser_panel_types {
 
 					widget = {
 						size = { 90 @spreadsheet_header_height }
-                        parentanchor = vcenter # MPM
 
 						textbox = {
 							visible = "[And(Not(BuildingType.IsGovernmentFunded), Not(BuildingType.IsSubsistenceBuilding))]"
@@ -686,8 +630,8 @@ types building_browser_panel_types {
 				}
 			}
 
-			dynamicgridbox = { # MPM - fixedgridbox -> dynamicgridbox
-				# addrow = @spreadsheet_height # MPM
+			fixedgridbox = {
+				addrow = @spreadsheet_height
 				addcolumn = @spreadsheet_width
 				datamodel = "[BuildingBrowserBuildingTypeItem.GetBuildings]"
 				datamodel_reuse_widgets = yes
@@ -695,9 +639,8 @@ types building_browser_panel_types {
 				visible = "[GetVariableSystem.Exists(Concatenate('building_browser_building_type_', BuildingType.GetIDString))]"
 
 				item = {
-					flowcontainer = { # MPM - widget -> flowcontainer
-						minimumsize = { @spreadsheet_width @spreadsheet_height } # MPM
-                        direction = vertical # MPM
+					widget = {
+						size = { @spreadsheet_width @spreadsheet_height }
 
 						building_browser_building_item = {
 							blockoverride "first_info" {
@@ -706,8 +649,6 @@ types building_browser_panel_types {
 									onrightclick = "[RightClickMenuManager.ShowForBuilding(Building.AccessSelf)]"
 									size = { 170 @spreadsheet_height }
 									using = default_button
-                                    
-                                    parentanchor = vcenter # MPM
 
 									hbox = {
 										layoutpolicy_horizontal = expanding
@@ -741,7 +682,6 @@ types building_browser_panel_types {
 
 								widget = {
 									size = { 120 @spreadsheet_height }
-                                    parentanchor = vcenter # MPM
 
 									flowcontainer = {
 										visible = "[Not(IsDataModelEmpty(Building.AccessState.AccessStateRegion.AccessTraits))]"
@@ -765,9 +705,7 @@ types building_browser_panel_types {
 
 								vertical_divider = {}
 
-								building_browser_item_ownership_area = {
-                                    parentanchor = vcenter # MPM
-                                }
+								building_browser_item_ownership_area = {}
 							}
 						}
 

--- a/gui/00_MPM_building_details_panel.gui
+++ b/gui/00_MPM_building_details_panel.gui
@@ -254,8 +254,8 @@ types building_panels
 				}
 
 				block "extra_items_in_production_methods_list" {}
-
-                # MPM - move progress bars in here to not clip with PMs
+                
+                # MPM - move progress bars into this container to not clip with PMs
                 block "building_progressbars" {
                     building_progressbars = {
                         position = { -5 0 }

--- a/gui/MPM_custom_types.gui
+++ b/gui/MPM_custom_types.gui
@@ -1,0 +1,195 @@
+types MPM_types {
+    type MPM_production_methods_scrollarea_base = container {
+        scrollarea = { # MPM - mostly copied from goods_state_panel
+            layoutpolicy_horizontal = expanding
+            layoutpolicy_vertical = expanding
+
+            block scrollarea_size {
+                size = { 208 50 }
+            }
+
+            scrollbarpolicy_vertical = always_off
+
+            scrollbar_horizontal = {
+                scrollbar = {
+                    name = "horizontal_scrollbar"
+                    wheelstep = 60
+                    direction = horizontal
+
+                    block scrollbar_size {
+                        size = { 8 6 }
+                    }
+
+                    track = {
+                        button = {
+                            texture = "gfx/interface/scrollbars/scrollbar_track_horizontal.dds"
+                            spriteType = Corneredtiled
+                            gfxtype = buttongfx
+                            spriteborder = { 3 0 }
+                            effectname = "NoHighlight"
+                            intersectionmask = yes
+
+                            block track_size {
+                                size = { 8 4 }
+                            }
+                        }
+                    }
+
+                    slider = {
+                        button = {
+                            name = sliderbutton
+                            texture = "gfx/interface/scrollbars/scrollbar_slider_horizontal.dds"
+                            gfxtype = framedbuttongfx
+                            effectname = "NoHighlight"
+                            upframe = 1
+                            overframe = 2
+                            downframe = 2
+                            intersectionmask = yes
+
+                            block slider_size {
+                                framesize = { 40 6 }
+                            }
+                        }
+                    }
+
+                    # delete these to instantly crash the game
+                    dec_button = {
+                        button = {
+                        }
+                    }
+
+                    inc_button = {
+                        button = {
+                        }
+                    }
+                }
+            }
+
+            scrollwidget = {
+                flowcontainer = {
+                    block scroll_datamodel {}
+
+                    block pm_spacing {
+                        spacing = 0
+                    }
+
+                    block pm_margins {
+                        margin_top = 6
+                    }
+
+                    item = {
+                        widget = {
+                            block item_widget {}
+                        }
+                    }
+                }
+            }
+        }
+	}
+
+    type MPM_pms_area_building = MPM_production_methods_scrollarea_base {
+        blockoverride scroll_datamodel {
+            datamodel = "[Building.AccessProductionMethodGroups]"
+        }
+
+        blockoverride item_widget {
+            block pm_size {
+                size = { 50 50 }
+            }
+            datacontext = "[Building.AccessProductionMethod(ProductionMethodGroup.Self)]"
+            datacontext = "[ProductionMethod]"
+            datacontext = "[Building]"
+            datacontext = "[ProductionMethodGroup]"
+            using = tooltip_above
+
+            tooltip = "CHANGE_FROM_CURRENT_PRODUCTION_METHOD_TOOLTIP"
+
+            button = {
+                visible = "[NotEqualTo_int32( GetDataModelSize( ProductionMethodGroup.AccessBuildingProductionMethods( Building.Self ) ), '(int32)1' )]"
+                using = expand_button_bg_dropdown
+                size = { 100% 100% }
+                enabled = "[Building.IsOwner( GetPlayer.Self )]"
+                onclick = "[RightClickMenuManager.ToggleSwitchProductionMethodMenu(Building.AccessSelf, ProductionMethodGroup.AccessSelf, PdxGuiWidget.AccessSelf)]"
+            }
+
+            icon = {
+                block pm_icon_size {
+                    size = { 40 40 }
+                }
+                parentanchor = center
+                texture = "[ProductionMethod.GetTexture]"
+            }
+        }
+    }
+
+    type MPM_pms_area_building_type = MPM_production_methods_scrollarea_base {
+        blockoverride scroll_datamodel {
+            datamodel = "[BuildingBrowserBuildingTypeItem.GetBuildingType.AccessProductionMethodGroups]"
+        }
+
+        blockoverride item_widget {
+            block pm_size {
+                size = { 50 50 }
+            }
+            tooltip = "BUILDING_TYPE_BULK_CHANGE_TOOLTIP"
+            using = tooltip_above
+
+            button = {
+                visible = "[NotEqualTo_int32( GetDataModelSize( ProductionMethodGroup.AccessCountryProductionMethods( GetPlayer.Self ) ), '(int32)1' )]"
+                distribute_visual_state = no
+                inherit_visual_state = no
+                using = expand_button_bg_dropdown
+                size = { 100% 100% }
+                onclick = "[BuildingBrowserBuildingTypeItem.ToggleSwitchProductionMethodMenu( ProductionMethodGroup.AccessSelf, PdxGuiWidget.AccessSelf)]"
+                enabled = "[Not(IsDataModelEmpty(BuildingBrowserBuildingTypeItem.GetBuildingsInCountry))]"
+            }
+
+            ### pm icon
+            icon = {
+                visible = "[BuildingBrowserBuildingTypeItem.HasAllSameProductionMethod( ProductionMethodGroup.Self )]"
+                block pm_icon_size {
+                    size = { 40 40 }
+                }
+                parentanchor = center
+                texture = "[BuildingBrowserBuildingTypeItem.GetAllSameProductionMethodTexture( ProductionMethodGroup.Self )]"
+            }
+
+            ### mixed pm icon
+            icon = {
+                visible = "[Not( BuildingBrowserBuildingTypeItem.HasAllSameProductionMethod( ProductionMethodGroup.Self ) )]"
+                block pm_icon_mixed_size {
+                    size = { 35 35 }
+                }
+                parentanchor = center
+                texture = "[ProductionMethodGroup.GetMixedIcon]"
+            }
+
+            ### new pm
+            has_new_pm_icon = {
+                position = { -2 2 }
+                parentanchor = bottom|left
+                blockoverride "visible" {
+                    visible = "[And(GetPlayer.HasNewProductionMethodInGroup( ProductionMethodGroup.Self ), Not(IsDataModelEmpty(BuildingBrowserBuildingTypeItem.GetBuildingsInCountry)))]"
+                }
+            }
+
+            ### nr available
+            textbox = {
+                raw_text = "#bold [ProductionMethodGroup.GetNumAvailableOptionsForBuildingType(BuildingBrowserBuildingTypeItem.GetBuildingType.AccessSelf)]#!"
+                parentanchor = top|right
+                position = { -5 0 }
+                autoresize = yes
+                align = right|nobaseline
+                visible = "[GreaterThan_int32( ProductionMethodGroup.GetNumAvailableOptionsForBuildingType(BuildingBrowserBuildingTypeItem.GetBuildingType.AccessSelf), '(int32)1')]"
+                tooltip = "PRODUCTION_METHOD_OPTIONS_BULK"
+                using = tooltip_above
+                using = fontsize_small
+
+                background = {
+                    using = default_background
+                    margin = { 8 4 }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Building Registry now uses a horizontal scrolling area to fit excess PMs instead of using a grid
- Fixed colliding PMs when using the ungrouped view in the Building Registry