### PR TITLE
Journal Entry Character Portrait Improvements & Universal Names Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ https://steamcommunity.com/sharedfiles/filedetails/?id=3385002128
 * [Weekly Event Framework](#weekly-event-framework)
 * [Hide/Show Journal Entry Groups](#hideshow-journal-entry-groups)
 * [Formation Event Blocker](#formation-event-blocker)
+* [Built-In Universal Names Compatibility](#built-in-universal-names-compatibility)
 
 # Setting Dependency
 
@@ -558,3 +559,28 @@ To allow formation events again, simply remove the variable.
 Notes:
 1. No considerations have been made regarding any failsafes. You are solely responsible for unblocking formation events later, even if the country successfully completes additional formations.
 2. Changing country via the `change_tag` effect will **not** remove the `com_no_formation_events`variable.
+
+# Built-In Universal Names Compatibility
+
+CMF sets up seamless compatibility with [FUN's Universal Names mod](https://steamcommunity.com/sharedfiles/filedetails/?id=2880875193) for its own use in certain GUI windows, but it can be used by any other mods as well.
+
+The Universal Names mod, among a few other things, corrects the display of full names for characters belonging to cultures whose full name order is `Last-First`, as opposed to `First-Last`, improving the presentation of relevant cultures, especially East Asian characters or Hungarians.
+
+Universal Names works by replacing `Character.GetFullName` calls in GUI and localization with a call to a customizable localization it defines. CMF defines clones of these custom locs in a manner that allows UN to overwrite them if UN is enabled; otherwise, CMF's definitions provide a fallback to the equivalent datafunctions. This allows seamless compatibility with compliant text - any applicable characters will either have their names displayed identically to vanilla, or their names will be fixed if the user has UN installed without any additional actions required on the user's part.
+
+In the interest of promoting this improved user experience, it is recommended to use the Universal Names custom locs for printing full names in any journals, events, GUIs, etc. whenever they are used. Below is a list of all the vanilla name datafunctions and their Universal Names custom locs counterparts which CMF provides seamless compatibility for:
+```
+Character.GetFullName                      => Character.GetCustom('GetUniversalFullName')
+Character.GetFullNameNoFormatting          => Character.GetCustom('GetUniversalFullNameNoFormatting')
+Character.GetFullNameWithTitle             => Character.GetCustom('GetUniversalFullNameWithTitle')
+Character.GetFullNameWithTitleNoFormatting => Character.GetCustom('GetUniversalFullNameWithTitleNoFormatting')
+Character.GetPrimaryRoleTitle              => Character.GetCustom('GetUniversalTitle')
+```
+Simple localization usage example:
+```
+original_text: "Hello, my name is [Character.GetFullNameNoFormatting]"
+improved_text: "Hello, my name is [Character.GetCustom('GetUniversalFullNameNoFormatting')]"
+```
+Consider a Korean character whose name in the real world would be written as `Yi Sun-sin`. Korean names are `Last-First` names, so `Sun-sin` is the given name and `Yi` is the surname.
+- With `original_text`, it would render as `Hello, my name is Sun-sin Yi`. In reality this would be *incorrect*.
+- With `improved_text`, it would render as `Hello, my name is Yi Sun-sin`. This is correct and improves character flavor!

--- a/STEAM_PAGE.bbcode
+++ b/STEAM_PAGE.bbcode
@@ -21,10 +21,10 @@ This part of the framework intends to deconflict mods that require GUI changes w
 [*]A way to add new buttons to the Sidebar (Credit to Bahmut, LordR, & Alexedishi)
 [*]Modification to the GUI template fullscreen_hide to hide the outliner whenever a scripted widget window is open (Credit to Bahmut & Alexedishi)
 [*]Modification to objective_types to add a scrollbar to the objectives screens. (Credit to Bahmut, KarafuruAmamiya and Xier)
-[*]Integration of the Modded DLC Framework (Credit to 1230James)
+[*]Integration of the Modded DLC Framework (Credit to 1230james)
 [*]Modification to the outliner and journal GUIs to hide custom objectives during gameplay (Credit to Taylor)
 [*]Several event windows for extra flavor (Credit to Bananaman & Klein for the Newspaper window, credit to Alexedishi for all others)
-[*]Integration of the Multi-line PM Framework (Credit to 1230James)
+[*]Integration of the Multi-line PM Framework (Credit to 1230james)
 [*]Modification to Journal Entry GUI to allow players to show characters (Credit to Bahmut and Mori)
 [*]Alerts can now open custom windows (Credit to Bahmut)
 [*]More than three local goods can now be shown in state building panel correctly (Credit to Bahmut)
@@ -38,7 +38,7 @@ This part of the framework intends to provide helper functions to modders that b
 [list]
 [*]Simple Structs to manage Variables (Credit to Bahmut)
 [*]Unified Keybind configuration to allow multiple mods to define Keybinds (Credit to Lord R)
-[*]Ability to block Heir notifications (Credit to 1230James)
+[*]Ability to block randomly-generated heirs (Credit to 1230james)
 [*]Ability to block Country Formation notifications (Credit to Alexedishi)
 [*]Community Mod triggers to detect other active mods
 [*]Framework for running weekly events without a Journal Entry (Credit to Dingbat32 and LordR)
@@ -56,7 +56,7 @@ These triggers allow mods to detect each other. This [b] does not[/b] automatica
 [b]Special Thanks to all to have contributed:[/b]
 [list]
 [*]Alexedishi
-[*]1230James
+[*]1230james
 [*]Bahmut
 [*]Bananaman
 [*]CaelReader

--- a/common/customizable_localization/00_com_universal_names.txt
+++ b/common/customizable_localization/00_com_universal_names.txt
@@ -1,0 +1,49 @@
+﻿# Custom loc definitions to enable seamless compatibility with FUN's Universal Names mod
+# https://steamcommunity.com/sharedfiles/filedetails/?id=2880875193
+
+# GetUniversalHistoricalFigures and GetUniversalHistoricalFiguresFormatted are deprecated, so they are not supported
+
+GetUniversalFullName = {
+	type = character
+	random_valid = no
+
+	text = {
+		localization_key = com_universal_names_full_name
+	}
+}
+
+GetUniversalFullNameNoFormatting = {
+	type = character
+	random_valid = no
+
+	text = {
+		localization_key = com_universal_names_full_name_no_fmt
+	}
+}
+
+GetUniversalFullNameWithTitle = {
+	type = character
+	random_valid = no
+
+	text = {
+		localization_key = com_universal_names_full_name_w_title
+	}
+}
+
+GetUniversalFullNameWithTitleNoFormatting = {
+	type = character
+	random_valid = no
+
+	text = {
+		localization_key = com_universal_names_full_name_w_title_no_fmt
+	}
+}
+
+GetUniversalTitle = {
+	type = character
+	random_valid = no
+
+	text = {
+		localization_key = com_universal_names_title
+	}
+}

--- a/gui/com_event_windows/com_character_event_windows.gui
+++ b/gui/com_event_windows/com_character_event_windows.gui
@@ -1309,7 +1309,7 @@ types com_character_window_types {
 			blockoverride "text" {}
 			parentanchor = top
 			textbox = {
-				text = "[Character.GetFullNameNoFormatting]"
+				text = "[Character.GetCustom('GetUniversalFullNameNoFormatting')]"
 				parentanchor = vcenter|hcenter
 				position = { 0 -2 }
 				autoresize = yes

--- a/gui/com_gui_journal_entry.gui
+++ b/gui/com_gui_journal_entry.gui
@@ -14,7 +14,7 @@
 @COM_panel_width_plus_20_half = @[panel_width_plus_20 / 2]
 
 types journal_entry_overwrites {
-	type journal_entry_panel = default_block_window {
+	type journal_entry_panel = default_block_window_two_lines {
 		name = "journal_entry_panel"
 		datacontext = "[JournalEntryPanel.AccessJournalEntry]"
 
@@ -29,7 +29,7 @@ types journal_entry_overwrites {
 		
 		blockoverride "window_header_name"
 		{
-			text = "[JournalEntry.GetName]"
+			text = "[LabelingHelper.CapitalizeOnlyFirst(JournalEntry.GetName)]"
 		}
 
 		blockoverride "window_header_name_line_two" {

--- a/gui/com_gui_journal_entry.gui
+++ b/gui/com_gui_journal_entry.gui
@@ -11,6 +11,8 @@
 @panel_width_plus_30 = 570			# used to be 490
 @panel_width_plus_70 = 610			# used to be 530
 
+@COM_panel_width_plus_20_half = @[panel_width_plus_20 / 2]
+
 types journal_entry_overwrites {
 	type journal_entry_panel = default_block_window {
 		name = "journal_entry_panel"
@@ -689,11 +691,11 @@ types journal_entry_overwrites {
 		block "character_context" {}
 
 		block "character_size" {
-			size = { @panel_width_half 290 }
+			size = { @COM_panel_width_plus_20_half 290 }
 		}
 
 		widget = {
-			size = { @panel_width_half 290 }
+			size = { @COM_panel_width_plus_20_half 290 }
 			parentanchor = hcenter
 
 			# Character Tooltip
@@ -722,7 +724,7 @@ types journal_entry_overwrites {
 					parentanchor = vcenter|hcenter
 					position = { 0 -2 }
 					autoresize = yes
-					max_width = @panel_width_half
+					max_width = @COM_panel_width_plus_20_half
 					using = fontsize_large
 				}
 			}
@@ -731,6 +733,8 @@ types journal_entry_overwrites {
 			flowcontainer = {
 				position = { 180 50 }
 				margin = { 10 10 }
+				visible = "[Character.MakeScope.Var('com_opinion').IsSet]"
+
 				tooltipwidget = {
 					RegularTooltip = {
 						blockoverride "text" {
@@ -787,7 +791,7 @@ types journal_entry_overwrites {
 					visible = "[IsOdd_int32(GetDataModelSize(JournalEntry.MakeScope.GetList('com_journal_characters')))]"
 				}
 				blockoverride "character_size" {
-					size = { @panel_width 290 }
+					size = { @panel_width_plus_20 290 }
 				}
 			}
 		}

--- a/gui/com_gui_journal_entry.gui
+++ b/gui/com_gui_journal_entry.gui
@@ -720,7 +720,7 @@ types journal_entry_overwrites {
 				blockoverride "text" {}
 				parentanchor = hcenter
 				textbox = {
-					text = "[Character.GetFullNameNoFormatting]"
+					text = "[Character.GetCustom('GetUniversalFullNameNoFormatting')]"
 					parentanchor = vcenter|hcenter
 					position = { 0 -2 }
 					autoresize = yes

--- a/localization/braz_por/com_universal_names_l_braz_por.yml
+++ b/localization/braz_por/com_universal_names_l_braz_por.yml
@@ -1,0 +1,6 @@
+﻿l_braz_por:
+    com_universal_names_title:     "[Character.GetPrimaryRoleTitle]"
+    com_universal_names_full_name: "[Character.GetFullName]"
+    com_universal_names_full_name_no_fmt:  "[Character.GetFullNameNoFormatting]"
+    com_universal_names_full_name_w_title: "[Character.GetFullNameWithTitle]"
+    com_universal_names_full_name_w_title_no_fmt: "[Character.GetFullNameWithTitleNoFormatting]"

--- a/localization/english/com_universal_names_l_english.yml
+++ b/localization/english/com_universal_names_l_english.yml
@@ -1,0 +1,6 @@
+﻿l_english:
+    com_universal_names_title:     "[Character.GetPrimaryRoleTitle]"
+    com_universal_names_full_name: "[Character.GetFullName]"
+    com_universal_names_full_name_no_fmt:  "[Character.GetFullNameNoFormatting]"
+    com_universal_names_full_name_w_title: "[Character.GetFullNameWithTitle]"
+    com_universal_names_full_name_w_title_no_fmt: "[Character.GetFullNameWithTitleNoFormatting]"

--- a/localization/french/com_universal_names_l_french.yml
+++ b/localization/french/com_universal_names_l_french.yml
@@ -1,0 +1,6 @@
+﻿l_french:
+    com_universal_names_title:     "[Character.GetPrimaryRoleTitle]"
+    com_universal_names_full_name: "[Character.GetFullName]"
+    com_universal_names_full_name_no_fmt:  "[Character.GetFullNameNoFormatting]"
+    com_universal_names_full_name_w_title: "[Character.GetFullNameWithTitle]"
+    com_universal_names_full_name_w_title_no_fmt: "[Character.GetFullNameWithTitleNoFormatting]"

--- a/localization/german/com_universal_names_l_german.yml
+++ b/localization/german/com_universal_names_l_german.yml
@@ -1,0 +1,6 @@
+﻿l_german:
+    com_universal_names_title:     "[Character.GetPrimaryRoleTitle]"
+    com_universal_names_full_name: "[Character.GetFullName]"
+    com_universal_names_full_name_no_fmt:  "[Character.GetFullNameNoFormatting]"
+    com_universal_names_full_name_w_title: "[Character.GetFullNameWithTitle]"
+    com_universal_names_full_name_w_title_no_fmt: "[Character.GetFullNameWithTitleNoFormatting]"

--- a/localization/japanese/com_universal_names_l_japanese.yml
+++ b/localization/japanese/com_universal_names_l_japanese.yml
@@ -1,0 +1,6 @@
+﻿l_japanese:
+    com_universal_names_title:     "[Character.GetPrimaryRoleTitle]"
+    com_universal_names_full_name: "[Character.GetFullName]"
+    com_universal_names_full_name_no_fmt:  "[Character.GetFullNameNoFormatting]"
+    com_universal_names_full_name_w_title: "[Character.GetFullNameWithTitle]"
+    com_universal_names_full_name_w_title_no_fmt: "[Character.GetFullNameWithTitleNoFormatting]"

--- a/localization/korean/com_universal_names_l_korean.yml
+++ b/localization/korean/com_universal_names_l_korean.yml
@@ -1,0 +1,6 @@
+﻿l_korean:
+    com_universal_names_title:     "[Character.GetPrimaryRoleTitle]"
+    com_universal_names_full_name: "[Character.GetFullName]"
+    com_universal_names_full_name_no_fmt:  "[Character.GetFullNameNoFormatting]"
+    com_universal_names_full_name_w_title: "[Character.GetFullNameWithTitle]"
+    com_universal_names_full_name_w_title_no_fmt: "[Character.GetFullNameWithTitleNoFormatting]"

--- a/localization/polish/com_universal_names_l_polish.yml
+++ b/localization/polish/com_universal_names_l_polish.yml
@@ -1,0 +1,6 @@
+﻿l_polish:
+    com_universal_names_title:     "[Character.GetPrimaryRoleTitle]"
+    com_universal_names_full_name: "[Character.GetFullName]"
+    com_universal_names_full_name_no_fmt:  "[Character.GetFullNameNoFormatting]"
+    com_universal_names_full_name_w_title: "[Character.GetFullNameWithTitle]"
+    com_universal_names_full_name_w_title_no_fmt: "[Character.GetFullNameWithTitleNoFormatting]"

--- a/localization/russian/com_universal_names_l_russian.yml
+++ b/localization/russian/com_universal_names_l_russian.yml
@@ -1,0 +1,6 @@
+﻿l_russian:
+    com_universal_names_title:     "[Character.GetPrimaryRoleTitle]"
+    com_universal_names_full_name: "[Character.GetFullName]"
+    com_universal_names_full_name_no_fmt:  "[Character.GetFullNameNoFormatting]"
+    com_universal_names_full_name_w_title: "[Character.GetFullNameWithTitle]"
+    com_universal_names_full_name_w_title_no_fmt: "[Character.GetFullNameWithTitleNoFormatting]"

--- a/localization/simp_chinese/com_universal_names_l_simp_chinese.yml
+++ b/localization/simp_chinese/com_universal_names_l_simp_chinese.yml
@@ -1,0 +1,6 @@
+﻿l_simp_chinese:
+    com_universal_names_title:     "[Character.GetPrimaryRoleTitle]"
+    com_universal_names_full_name: "[Character.GetFullName]"
+    com_universal_names_full_name_no_fmt:  "[Character.GetFullNameNoFormatting]"
+    com_universal_names_full_name_w_title: "[Character.GetFullNameWithTitle]"
+    com_universal_names_full_name_w_title_no_fmt: "[Character.GetFullNameWithTitleNoFormatting]"

--- a/localization/spanish/com_universal_names_l_spanish.yml
+++ b/localization/spanish/com_universal_names_l_spanish.yml
@@ -1,0 +1,6 @@
+﻿l_spanish:
+    com_universal_names_title:     "[Character.GetPrimaryRoleTitle]"
+    com_universal_names_full_name: "[Character.GetFullName]"
+    com_universal_names_full_name_no_fmt:  "[Character.GetFullNameNoFormatting]"
+    com_universal_names_full_name_w_title: "[Character.GetFullNameWithTitle]"
+    com_universal_names_full_name_w_title_no_fmt: "[Character.GetFullNameWithTitleNoFormatting]"

--- a/localization/turkish/com_universal_names_l_turkish.yml
+++ b/localization/turkish/com_universal_names_l_turkish.yml
@@ -1,0 +1,6 @@
+﻿l_turkish:
+    com_universal_names_title:     "[Character.GetPrimaryRoleTitle]"
+    com_universal_names_full_name: "[Character.GetFullName]"
+    com_universal_names_full_name_no_fmt:  "[Character.GetFullNameNoFormatting]"
+    com_universal_names_full_name_w_title: "[Character.GetFullNameWithTitle]"
+    com_universal_names_full_name_w_title_no_fmt: "[Character.GetFullNameWithTitleNoFormatting]"


### PR DESCRIPTION
- Updated journal entry header to catch up with 1.9
- Fixed opinion bubble always appearing on character portraits in journal entries that had characters displayed when no opinion flag was added for the character
- Fixed character portraits in journal entries being off-center
- Added code infrastructure to facilitate seamless compatibility with [FUN's Universal Names mod](https://steamcommunity.com/sharedfiles/filedetails/?id=2880875193)
- Tweaked character portraits in journal entries & 3 character selection event window to use Universal Names for printing names