### PR TITLE
Hide goods with an invalid category from goods lists

### DIFF
--- a/gui/00_com_market_panel.gui
+++ b/gui/00_com_market_panel.gui
@@ -1,0 +1,127 @@
+##############################
+# COMMUNITY GUI MARKET PANEL #
+##############################
+
+# This modification is to hide invalid goods
+
+# COPY-PASTED FOR NOW
+@panel_width_minus_10 = 530			# used to be 450
+@panel_width = 540  				# used to be 460
+@panel_width_half = 270				# used to be 230
+@panel_width_plus_10 = 550  		# used to be 470
+@panel_width_plus_14 = 554			# used to be 474
+@panel_width_plus_14_half = 277		# used to be 237
+@panel_width_plus_20 = 560			# used to be 480
+@panel_width_plus_30 = 570			# used to be 490
+@panel_width_plus_70 = 610			# used to be 530
+
+types com_market_panel_overwrites
+{
+	type market_panel_details_content = container {
+		parentanchor = hcenter
+		
+		flowcontainer = {
+			direction = vertical
+			using = default_list_position
+			margin_bottom = 20
+
+			flowcontainer = {
+				using = default_list_position
+				direction = vertical
+				spacing = 20
+				
+				flowcontainer = {
+					name = "tutorial_highlight_market_details_panel_all_goods"
+					direction = vertical
+					datamodel = "[Market.AccessMarketGoods( MarketPanel.GetFilters )]"
+					spacing = 2
+					parentanchor = hcenter
+					
+					item = {
+						visible = "[Not(EqualTo_CFixedPoint(Goods.GetBasePrice, '(CFixedPoint)0'))]"
+						goods_entry_button = {}
+					}
+				}
+				
+				flowcontainer = {
+					direction = vertical
+					visible = "[Not(IsDataModelEmpty(Market.AccessLocalGoods( MarketPanel.GetFilters )))]"
+					
+					default_header_2texts = {
+						parentanchor = hcenter
+						blockoverride "text1" {
+							text = "LOCAL_GOODS"
+						}
+					}	
+
+					widget = { size = { 5 5 } }		
+					
+					flowcontainer = {
+						wrap_count = 10
+						datamodel = "[Market.AccessLocalGoods( MarketPanel.GetFilters )]"
+						margin_left = 10
+						spacing = 5
+						
+						item = {
+							container = {
+								visible = "[Not(EqualTo_string(Goods.GetCategoryName, ''))]"
+
+								tooltipwidget = {
+									FancyTooltip_Goods = {}
+								}	
+					
+								button_icon_round = {
+									size = { 50 50 }
+									using = select_button_sound
+									onclick = "[InformationPanelBar.OpenGoodsLocalPricesPanel(Goods.Self)]"
+									onrightclick = "[RightClickMenuManager.ShowForGoods(Goods.AccessSelf)]"
+								}
+								
+								icon = {
+									size = { 50 50 }
+									texture = "[Goods.GetTexture]"
+								}								
+							}
+						}
+					}							
+				}					
+				
+				textbox = {
+					text = "[Market.GetModifier.GetFullEntryDescFor('market_land_trade_capacity_add')]"
+					visible = "[InDebugMode]"
+					
+					parentanchor = hcenter
+					minimumsize = { 450 -1 }
+					autoresize = yes
+					multiline = yes
+					margin = { 0 10 }
+					align = center|nobaseline
+					
+					background = {
+						using = entry_bg
+					}
+				}
+
+				textbox = {
+					text = "[Market.GetModifierDesc]"
+					visible = "[And(InDebugMode, Not(StringIsEmpty(Market.GetModifierDesc)))]"
+					
+					parentanchor = hcenter
+					minimumsize = { 450 -1 }
+					autoresize = yes
+					multiline = yes
+					margin = { 0 10 }
+					align = center|nobaseline
+					
+					background = {
+						using = entry_bg
+					}
+				}
+			}
+		}
+
+		not_yet_initialized = {
+			visible = "[EqualTo_CFixedPoint(Market.GetBalance, '(CFixedPoint)0')]"
+		}
+	}
+}

--- a/gui/00_com_states_panel.gui
+++ b/gui/00_com_states_panel.gui
@@ -1,0 +1,693 @@
+# COPY-PASTED FOR NOW
+@panel_width_minus_10 = 530			# used to be 450
+@panel_width = 540  				# used to be 460
+@panel_width_half = 270				# used to be 230
+@panel_width_plus_10 = 550  		# used to be 470
+@panel_width_plus_14 = 554			# used to be 474
+@panel_width_plus_14_half = 277		# used to be 237
+@panel_width_plus_20 = 560			# used to be 480
+@panel_width_plus_30 = 570			# used to be 490
+@panel_width_plus_70 = 610			# used to be 530
+
+types com_state_panel_types_overwrites
+{
+	type states_panel =  default_block_window_two_lines {
+		name = "states_panel"
+		datacontext = "[StatesPanel.AccessState]"
+
+		blockoverride "window_header_name"
+		{
+			raw_text = "[LabelingHelper.CapitalizeOnlyFirst(State.GetNameNoFormatting)]"
+
+			tooltipwidget = {
+				FancyTooltip_State = {}
+			}
+		}
+
+		blockoverride "window_header_name_line_two" {
+			text = "STATE_IN_COUNTRY_SUBTITLE"
+		}
+
+		blockoverride "goto_button" {
+			button_icon_goto = {
+				datacontext = "[StatesPanel.GetState.GetCountry]"
+				size = { 30 30 }
+				onclick = "[InformationPanelBar.OpenCountryPanel(StatesPanel.GetState.GetCountry)]"
+				tooltip = "GO_TO_BUTTON_COUNTRY"
+				input_action = "go_to_details"
+			}
+		}
+
+		blockoverride "edit_visibility" {
+			visible = "[StatesPanel.GetState.GetCountry.IsPlayer]"
+		}
+
+		blockoverride "edit_tooltip" {
+			tooltip = "CUSTOMIZE_STATE_NAMES"
+		}
+
+		blockoverride "edit_properties" {
+			onclick = "[PopupManager.ShowStateChangeName(StatesPanel.GetState.Self)]"
+		}
+
+		blockoverride "fixed_top" {
+			tab_buttons = {
+
+				# Overview
+				blockoverride "first_button" {
+					text = "OVERVIEW"
+				}
+				blockoverride "first_button_tooltip" {
+					tooltip = "OVERVIEW"
+				}
+				blockoverride "first_button_click" {
+					onclick = "[InformationPanel.SelectTab('default')]"
+				}
+				blockoverride "first_button_visibility" {
+					visible = "[InformationPanel.IsTabSelected('default')]"
+				}
+
+				blockoverride "first_button_visibility_checked" {
+					visible = "[Not( InformationPanel.IsTabSelected('default') )]"
+				}
+				blockoverride "first_button_selected" {
+					text = "OVERVIEW"
+				}
+				blockoverride "first_button_name" {
+					name = "tutorial_highlight_state_overview"
+				}
+
+				# Buildings
+				blockoverride "second_button" {
+					text = "BUILDINGS"
+				}
+				blockoverride "second_button_tooltip" {
+					tooltip = "BUILDINGS"
+				}
+				blockoverride "second_button_click" {
+					onclick = "[InformationPanel.SelectTab('buildings')]"
+				}
+				blockoverride "second_button_visibility" {
+					visible = "[InformationPanel.IsTabSelected('buildings')]"
+				}
+				blockoverride "second_button_visibility_checked" {
+					visible = "[Not( InformationPanel.IsTabSelected('buildings') )]"
+				}
+				blockoverride "second_button_selected" {
+					text = "BUILDINGS"
+				}
+				blockoverride "second_button_name" {
+					name = "tutorial_highlight_building_tab"
+				}
+
+				# Information
+				blockoverride "third_button" {
+					text = "POPULATION"
+				}
+				blockoverride "third_button_tooltip" {
+					tooltip = "POPULATION"
+				}
+				blockoverride "third_button_click" {
+					onclick = "[InformationPanel.SelectTab('population')]"
+				}
+				blockoverride "third_button_visibility" {
+					visible = "[InformationPanel.IsTabSelected('population')]"
+				}
+				blockoverride "third_button_visibility_checked" {
+					visible = "[Not( InformationPanel.IsTabSelected('population') )]"
+				}
+				blockoverride "third_button_selected" {
+					text = "POPULATION"
+				}
+				blockoverride "third_button_name" {
+					name = "tutorial_highlight_state_population_tab"
+				}
+
+				# Local Goods
+				blockoverride "fourth_button" {
+					text = "LOCAL_PRICES"
+				}
+				blockoverride "fourth_button_tooltip" {
+					tooltip = "LOCAL_PRICES"
+				}
+				blockoverride "fourth_button_click" {
+					onclick = "[InformationPanel.SelectTab('local_goods')]"
+				}
+				blockoverride "fourth_button_visibility" {
+					visible = "[InformationPanel.IsTabSelected('local_goods')]"
+				}
+				blockoverride "fourth_button_visibility_checked" {
+					visible = "[Not( InformationPanel.IsTabSelected('local_goods') )]"
+				}
+				blockoverride "fourth_button_selected" {
+					text = "LOCAL_PRICES"
+				}
+
+				# Information
+				blockoverride "fifth_button" {
+					text = "INFORMATION"
+				}
+				blockoverride "fifth_button_tooltip" {
+					tooltip = "INFORMATION"
+				}
+				blockoverride "fifth_button_click" {
+					onclick = "[InformationPanel.SelectTab('modifiers')]"
+				}
+				blockoverride "fifth_button_visibility" {
+					visible = "[InformationPanel.IsTabSelected('modifiers')]"
+				}
+				blockoverride "fifth_button_visibility_checked" {
+					visible = "[Not( InformationPanel.IsTabSelected('modifiers') )]"
+				}
+				blockoverride "fifth_button_selected" {
+					text = "INFORMATION"
+				}
+			}
+		}
+
+		blockoverride "highlight_name" {
+			name = "tutorial_highlight_second_header"
+		}
+
+		blockoverride "scrollarea_content"
+		{
+			container = {
+				parentanchor = hcenter
+
+				state_panel_overview_content = {
+					visible = "[And(Not(GetVariableSystem.Exists('state_panel_condensed')), InformationPanel.IsTabSelected('default'))]"
+					using = default_content_fade
+				}
+
+				state_panel_condensed = {
+					visible = "[And(GetVariableSystem.Exists('state_panel_condensed'), InformationPanel.IsTabSelected('default'))]"
+					using = default_content_fade
+				}
+
+				state_panel_buildings_content = {
+					visible = "[InformationPanel.IsTabSelected('buildings')]"
+					using = default_content_fade
+
+					### To remove the "Right-click to open context menu" on buildings for States not owned by the player
+					onmousehierarchyenter = "[SetCanOpenRightClickContextMenu( ObjectsEqual(StatesPanel.GetState.GetCountry.Self, GetMetaPlayer.GetPlayedOrObservedCountry.Self) )]"
+					onmousehierarchyleave = "[SetCanOpenRightClickContextMenu( '(bool)yes' )]"
+				}
+
+				state_panel_population_content = {}
+
+				state_panel_modifiers_content = {
+					visible = "[InformationPanel.IsTabSelected('modifiers')]"
+					using = default_content_fade
+				}
+
+				flowcontainer = {
+					visible =  "[InformationPanel.IsTabSelected('local_goods')]"
+					parentanchor = hcenter
+					direction = vertical
+
+					flowcontainer = {
+						using = default_list_position
+						margin = { 0 5 }
+						margin_top = 10
+
+						sort_button = {
+							size = { 55 20 }
+							tooltip = "SORT_BY_MARKET_GOODS"
+							button = {
+								texture = "gfx/interface/buttons/sort_button_icons/sort_icon_good.dds"
+								size = { 25 25 }
+								parentanchor = center
+								alwaystransparent = yes
+							}
+
+							onclick = "[StatesPanel.Sort('name')]"
+						}
+
+						sort_button = {
+							align = hcenter|nobaseline
+							tooltip = "SORT_BY_PRODUCTION"
+							size = { 55 20 }
+
+							onclick = "[StatesPanel.Sort('production')]"
+
+							button = {
+								texture = "gfx/interface/buttons/sort_button_icons/sort_production.dds"
+								size = { 25 25 }
+								parentanchor = center
+								alwaystransparent = yes
+							}
+						}
+
+						sort_button = {
+							align = hcenter|nobaseline
+							tooltip = "SORT_BY_CONSUMPTION"
+							size = { 60 20 }
+							margin_right = 7
+
+							onclick = "[StatesPanel.Sort('consumption')]"
+
+							button = {
+								texture = "gfx/interface/buttons/sort_button_icons/sort_consumption.dds"
+								size = { 25 25 }
+								parentanchor = center
+								alwaystransparent = yes
+							}
+						}
+
+						sort_button = {
+							align = hcenter|nobaseline
+							size = { 90 20 }
+							margin_right = 7
+							tooltip = "SORT_BY_BALANCE_TOOLTIP"
+
+							onclick = "[StatesPanel.Sort('balance')]"
+
+							button = {
+								texture = "gfx/interface/buttons/sort_button_icons/sort_balance.dds"
+								size = { 25 25 }
+								parentanchor = center
+								alwaystransparent = yes
+							}
+						}
+
+						sort_button = {
+							align = hcenter|nobaseline
+							text = "concept_local_price"
+							size = { 100 20 }
+
+							onclick = "[StatesPanel.Sort('state_price_relative_to_base')]"
+						}
+
+						sort_button = {
+							align = hcenter|nobaseline
+							text = "concept_market_price"
+							tooltip = "concept_market_price"
+							size = { 100 20 }
+
+							onclick = "[StatesPanel.Sort('market_price_relative_to_base')]"
+						}
+
+						sort_button = {
+							align = hcenter|nobaseline
+							text = "PRICE_DIFFERENCE"
+							tooltip = "PRICE_DIFFERENCE"
+							size = { 80 20 }
+
+							onclick = "[StatesPanel.Sort('price_difference')]"
+						}
+					}
+
+					flowcontainer = {
+						datamodel = "[StatesPanel.AccessLocalGoods]"
+						direction = vertical
+						parentanchor = hcenter
+
+						item = {
+							button = {
+								visible = "[Not(EqualTo_string(Goods.GetCategoryName, ''))]"
+								size = { @panel_width 50 }
+								using = default_button
+								onclick = "[InformationPanelBar.OpenGoodsStatePanel(State.Self, Goods.Self)]"
+								using = select_button_sound
+								onrightclick = "[RightClickMenuManager.ShowForGoods(Goods.AccessSelf)]"
+
+								block "tooltip" {
+								}
+
+								flowcontainer = {
+									parentanchor = vcenter
+									widgetanchor = vcenter
+
+									using = goods_list_item
+
+									flowcontainer = {
+											direction = vertical
+											spacing =  3
+											parentanchor = vcenter
+
+											textbox = {
+												text = "[Goods.GetStateProductionWithTooltip|Dv]"
+												alpha = "[TransparentIfZero(Goods.GetStateProduction)]"
+												align = hcenter|nobaseline
+												size = { 60 23 }
+												margin_right = 3
+												margin_left = 3
+												fontsize_min = 12
+											}
+
+											widget = {
+												tooltip = "STATE_GOODS_IMPORT_DEPENDENCE"
+												tooltipwidget = {
+													RegularTooltip_StateWorldMarketImportDependence = {}
+												}
+
+												visible = "[NotZero_CFixedPoint(Goods.GetStateImports)]"
+
+												parentanchor = hcenter
+												size = { 46 6 }
+
+												gold_progressbar_horizontal = {
+													size = { 100% 100% }
+
+													blockoverride "values" {
+														min = 0
+														max = "[Goods.GetStateProduction]"
+														value = "[Goods.GetStateImports]"
+													}
+												}
+											}
+										}
+
+										vertical_divider = {}
+
+										flowcontainer = {
+											direction = vertical
+											spacing =  3
+											parentanchor = vcenter
+
+											textbox = {
+												align = hcenter|nobaseline
+												text = "[Goods.GetStateConsumptionWithTooltip|Dv]"
+												size = { 60 23 }
+												fontsize_min = 12
+												margin_right = 3
+												margin_left = 3
+												alpha = "[TransparentIfZero(Goods.GetStateConsumption)]"
+											}
+
+											widget = {
+												tooltip = "STATE_GOODS_EXPORT_DEPENDENCE"
+												tooltipwidget = {
+													RegularTooltip_StateWorldMarketExportDependence = {}
+												}
+												visible = "[NotZero_CFixedPoint(Goods.GetStateExports)]"
+												parentanchor = hcenter
+												size = { 46 6 }
+
+												gold_progressbar_horizontal = {
+													size = { 100% 100% }
+
+													blockoverride "values" {
+														min = 0
+														max = "[Goods.GetStateConsumption]"
+														value = "[Goods.GetStateExports]"
+													}
+												}
+											}
+										}
+
+
+									vertical_divider = {}
+
+									flowcontainer = {
+										direction = vertical
+										minimumsize = { 90 52 }
+										margin_top = 10
+										spacing = 5
+										tooltip = "STATE_GOODS_BALANCE_TOOLTIP"
+
+										textbox = {
+											visible = "[GreaterThan_int32(FixedPointToInt(Goods.GetStateProductionConsumptionDiff), '(int32)0')]"
+											align = right|nobaseline
+											text = "GOODS_LOCAL_PRICE_PANEL_BALANCE_GOLD"
+											autoresize = yes
+											margin_right = 15
+											parentanchor = right
+										}
+
+										textbox = {
+											visible = "[EqualTo_int32(FixedPointToInt(Goods.GetStateProductionConsumptionDiff), '(int32)0')]"
+											align = hcenter|nobaseline
+											text = "GOODS_LOCAL_PRICE_PANEL_BALANCE"
+											autoresize = yes
+											parentanchor = hcenter
+										}
+
+										textbox = {
+											visible = "[LessThan_int32(FixedPointToInt(Goods.GetStateProductionConsumptionDiff), '(int32)0')]"
+											align = left|nobaseline
+											text = "GOODS_LOCAL_PRICE_PANEL_BALANCE_BLUE"
+											autoresize = yes
+											margin_left = 15
+											parentanchor = left
+										}
+
+										double_direction_progressbar_gold = {
+											size = { 60 6 }
+											parentanchor = hcenter
+
+											blockoverride "negative_min_max_values" {
+												min = "[Negate_float(FixedPointToFloat(Goods.GetState.GetMaxImbalanceScaledByBasePrice))]"
+												max = 0
+											}
+
+											blockoverride "positive_min_max_values" {
+												min = 0
+												max = "[FixedPointToFloat(Goods.GetState.GetMaxImbalanceScaledByBasePrice)]"
+											}
+
+											blockoverride "value_left" {
+												value = "[FixedPointToInt(Multiply_CFixedPoint(Goods.GetStateProductionConsumptionDiff, Goods.GetBasePrice))]"
+											}
+											blockoverride "value_right" {
+												value = "[FixedPointToInt(Multiply_CFixedPoint(Goods.GetStateProductionConsumptionDiff, Goods.GetBasePrice))]"
+											}
+										}
+									}
+
+									vertical_divider = {}
+
+									container = {
+										tooltip = "[Goods.GetStatePriceDesc]"
+										minimumsize = { 100 -1 }
+										parentanchor = vcenter
+
+										flowcontainer = {
+											spacing = 5
+											direction = vertical
+											parentanchor = hcenter
+
+											textbox = {
+												text = "GOODS_LOCAL_PRICE_INFO"
+												align = hcenter|nobaseline
+												autoresize = yes
+												parentanchor = hcenter
+											}
+
+											double_direction_progressbar_gold = {
+												visible = no
+												size = { 60 6 }
+												parentanchor = hcenter
+
+												blockoverride "negative_min_max_values" {
+													min = -0.75
+													max = 0
+												}
+
+												blockoverride "positive_min_max_values" {
+													min = 0
+													max = 0.75
+												}
+
+												blockoverride "value_left" {
+													value = "[FixedPointToFloat(Goods.GetPercentageDeltaAgainstBasePrice(Goods.GetStatePrice))]"
+												}
+												blockoverride "value_right" {
+													value = "[FixedPointToFloat(Goods.GetPercentageDeltaAgainstBasePrice(Goods.GetStatePrice))]"
+												}
+											}
+										}
+									}
+
+									vertical_divider = {}
+
+									container = {
+										using = market_price_tooltip_with_graph
+										minimumsize = { 100 -1 }
+										parentanchor = vcenter
+
+										flowcontainer = {
+											spacing = 5
+											direction = vertical
+											parentanchor = hcenter
+
+											textbox = {
+												visible = "[Not(Goods.IsLocal)]"
+												raw_text = "@money![Goods.GetMarketPrice|0v] [Goods.GetCompareIconAgainstBasePriceNoFormatting( Goods.GetMarketPrice )]"
+												align = hcenter|nobaseline
+												autoresize = yes
+												parentanchor = hcenter
+											}
+
+											textbox = {
+												visible = "[Goods.IsLocal]"
+												alpha = "[TransparentIfTrue(Goods.IsLocal)]"
+												align = hcenter|nobaseline
+												autoresize = yes
+												parentanchor = hcenter
+												text = "NOT_AVAILABLE"
+												tooltip = "concept_local_good_desc"
+											}
+
+											double_direction_progressbar_gold = {
+												visible = no
+												size = { 60 6 }
+												parentanchor = hcenter
+
+												blockoverride "negative_min_max_values" {
+													min = -0.75
+													max = 0
+												}
+
+												blockoverride "positive_min_max_values" {
+													min = 0
+													max = 0.75
+												}
+
+												blockoverride "value_left" {
+													value = "[FixedPointToFloat(Goods.GetPercentageDeltaAgainstBasePrice(Goods.GetMarketPrice))]"
+												}
+												blockoverride "value_right" {
+													value = "[FixedPointToFloat(Goods.GetPercentageDeltaAgainstBasePrice(Goods.GetMarketPrice))]"
+												}
+											}
+										}
+									}
+
+									vertical_divider = {}
+
+									widget = {
+										size = { 70 40 }
+										parentanchor = vcenter
+
+										textbox = {
+											visible = "[Not(Goods.IsLocal)]"
+											align = right|nobaseline
+											text = "[Goods.GetStateToMarketPriceDiff|%0=-]"
+											size = { 70 40 }
+											margin_right = 10
+											tooltip = "STATE_TO_MARKET_PRICE_DIFF_TOOLTIP"
+										}
+
+										textbox = {
+											visible = "[Goods.IsLocal]"
+											alpha = "[TransparentIfTrue(Goods.IsLocal)]"
+											align = right|nobaseline
+											text = "NOT_AVAILABLE"
+											tooltip = "concept_local_good_desc"
+											size = { 70 40 }
+											margin_right = 10
+										}
+									}
+								}
+							}
+						}
+					}
+
+
+					flowcontainer = {
+						direction = vertical
+						visible = "[Not(IsDataModelEmpty(StatesPanel.AccessNonLocalGoods))]"
+
+						widget = { size = { 20 20 } }
+
+						default_header_2texts = {
+							datacontext = "[StatesPanel.GetState]"
+							parentanchor = hcenter
+							blockoverride "text1" {
+								text = "NON_LOCAL_GOODS"
+							}
+						}
+
+						widget = { size = { 5 5 } }
+
+						dynamicgridbox = {
+							flipdirection = yes
+							datamodel_wrap = 10
+							datamodel = "[StatesPanel.AccessNonLocalGoods]"
+
+							item = {
+								container = {
+									tooltipwidget = {
+										FancyTooltip_Goods = {}
+									}
+
+									button_icon_round = {
+										size = { 50 50 }
+										using = select_button_sound
+										onclick = "[InformationPanelBar.OpenGoodsStatePanel(State.Self, Goods.Self)]"
+										onrightclick = "[RightClickMenuManager.ShowForGoods(Goods.AccessSelf)]"
+									}
+
+									icon = {
+										size = { 50 50 }
+										texture = "[Goods.GetTexture]"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		blockoverride "fixed_bottom"
+		{
+			widget = {
+				size = { 5 5 }
+				visible = "[InformationPanel.IsTabSelected('buildings')]"
+			}
+			state_panel_buildings_fixed_bottom = {
+				visible = "[InformationPanel.IsTabSelected('buildings')]"
+			}
+		}
+
+		blockoverride "pin_visibility" {
+			visible = "[ObjectsEqual(State.GetOwner, GetPlayer.Self)]"
+		}
+
+		blockoverride "pin_properties" {
+			visible = "[StatesPanel.AccessState.IsPinnedInOutliner]"
+			onclick = "[StatesPanel.AccessState.TogglePinInOutliner]"
+			datacontext = "[StatesPanel.AccessState]"
+			tooltip = "UNPIN_STATE"
+		}
+
+		blockoverride "unpin_properties" {
+			visible = "[Not(StatesPanel.AccessState.IsPinnedInOutliner)]"
+			onclick = "[StatesPanel.AccessState.TogglePinInOutliner]"
+			datacontext = "[StatesPanel.AccessState]"
+			tooltip = "PIN_STATE"
+		}
+
+		blockoverride "goto_visibility" {
+			visible = yes
+		}
+
+		blockoverride "custom_goto_button" {
+			onmousehierarchyenter = "[SetCanOpenRightClickContextMenu( '(bool)no' )]"
+			onmousehierarchyleave = "[SetCanOpenRightClickContextMenu( '(bool)yes' )]"
+
+			button_icon_zoom = {
+				onclick = "[State.ZoomToCapital]"
+				onrightclick = "[GetVariableSystem.Toggle('zoom_close_to_capital')]"
+				visible = "[Not(GetVariableSystem.Exists('zoom_close_to_capital'))]"
+
+				tooltip = "ZOOM_TO_STATE"
+				input_action = "zoom_to"
+				size = { 100% 100% }
+			}
+
+			button_icon_zoom = {
+				onclick = "[State.ZoomExtraCloseToCapital]"
+				onrightclick = "[GetVariableSystem.Toggle('zoom_close_to_capital')]"
+				visible = "[GetVariableSystem.Exists('zoom_close_to_capital')]"
+
+				tooltip = "ZOOM_CLOSE_TO_STATE"
+				input_action = "zoom_to"
+				size = { 100% 100% }
+			}
+
+		}
+	}
+}


### PR DESCRIPTION
This is so that goods can be used to selectively enable PMs, without cluttering up the goods lists.

For example, the following could be used to select PMs based on whether a state is coastal, without any additional goods showing in the UI
```
# common/goods/hidden_goods.txt
coastal_state = {
	texture = "gfx/interface/icons/goods_icons/clippers.dds"
	cost = 1
	category = hidden
	local = yes
}
```

```
# common/static_modifiers/99_code_static_modifiers_overwrite.txt
coastal_state = {
	icon = gfx/interface/icons/timed_modifier_icons/modifier_gear_positive.dds
	state_infrastructure_from_population_max_add = 10
	state_infrastructure_from_population_mult = 0.05
	state_sell_orders_coastal_state_add = 1
}
```

```
# common/production_methods/enabled_by_coast.txt
inland_pm = {
	replacement_if_valid = coastal_pm
	...
}

coastal_pm = {
	required_input_goods = coastal_state
	...
}
```